### PR TITLE
AOS-2777 exception handling

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/integration/boober/BooberWebClient.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/integration/boober/BooberWebClient.kt
@@ -7,7 +7,6 @@ import no.skatteetaten.aurora.gobo.integration.SourceSystemException
 import no.skatteetaten.aurora.gobo.integration.mokey.ApplicationDeploymentRefResource
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
-import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
@@ -73,15 +72,6 @@ class BooberWebClient(
         val response: Mono<Response> = fn(webClient)
             .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
             .retrieve()
-            .onStatus(HttpStatus::isError) {
-                it.bodyToMono<String>().defaultIfEmpty("").map { body ->
-                    SourceSystemException(
-                        message = "Failed request to boober, status:${it.statusCode().value()} message:${it.statusCode().reasonPhrase}",
-                        code = it.statusCode().value().toString(),
-                        errorMessage = body
-                    )
-                }
-            }
             .bodyToMono()
         return response.flatMapMany { r ->
                 if (!r.success) SourceSystemException(r.message).toFlux()

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/integration/imageregistry/ImageRegistryServiceBlocking.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/integration/imageregistry/ImageRegistryServiceBlocking.kt
@@ -56,13 +56,13 @@ class ImageRegistryServiceBlocking(
         return try {
             val manifestsUrl = urlBuilder.createManifestsUrl(registryMetadata.apiSchema, imageRepoDto, tag)
             getManifest(manifestsUrl, registryMetadata.authenticationMethod)
-                ?.let { parseMainfest(it) }
+                ?.let { parseManifest(it) }
         } catch (e: Exception) {
             throw SourceSystemException("Unable to get manifest for image: $tag", e)
         }
     }
 
-    private fun parseMainfest(manifestString: String): ImageMetadata {
+    private fun parseManifest(manifestString: String): ImageMetadata {
 
         val manifest = objectMapper.readTree(manifestString)
         val manifestHistory = manifest.get("history").get(0).get("v1Compatibility")

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/integration/mokey/affiliationServices.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/integration/mokey/affiliationServices.kt
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Mono
+import java.time.Duration
 
 @Service
 class AffiliationService(@TargetService(ServiceTypes.MOKEY) val webClient: WebClient) {
@@ -32,8 +33,10 @@ class AffiliationService(@TargetService(ServiceTypes.MOKEY) val webClient: WebCl
 class AffiliationServiceBlocking(private val affiliationService: AffiliationService) {
 
     fun getAllVisibleAffiliations(token: String): List<String> =
-        affiliationService.getAllVisibleAffiliations(token).blockNonNullAndHandleError()
+        affiliationService.getAllVisibleAffiliations(token).blockNonNullWithTimeout()
 
     fun getAllAffiliations(): List<String> =
-        affiliationService.getAllAffiliations().blockNonNullAndHandleError()
+        affiliationService.getAllAffiliations().blockNonNullWithTimeout()
+
+    private fun <T> Mono<T>.blockNonNullWithTimeout() = this.blockNonNullAndHandleError(Duration.ofSeconds(30))
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/integration/mokey/applicationServices.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/integration/mokey/applicationServices.kt
@@ -16,21 +16,22 @@ import java.time.Duration
 @Service
 class ApplicationServiceBlocking(private val applicationService: ApplicationService) {
     fun getApplications(affiliations: List<String>, applications: List<String>? = null) =
-        applicationService.getApplications(affiliations, applications).wait()
+        applicationService.getApplications(affiliations, applications).blockNonNullWithTimeout()
 
     fun getApplication(id: String): ApplicationResource =
-        applicationService.getApplication(id).wait()
+        applicationService.getApplication(id).blockNonNullWithTimeout()
 
     fun getApplicationDeployment(applicationDeploymentId: String) =
-        applicationService.getApplicationDeployment(applicationDeploymentId).wait()
+        applicationService.getApplicationDeployment(applicationDeploymentId).blockNonNullWithTimeout()
 
     fun getApplicationDeploymentDetails(token: String, applicationDeploymentId: String) =
-        applicationService.getApplicationDeploymentDetails(token, applicationDeploymentId).wait()
+        applicationService.getApplicationDeploymentDetails(token, applicationDeploymentId).blockNonNullWithTimeout()
 
     fun refreshApplicationDeployment(token: String, refreshParams: RefreshParams) =
-        applicationService.refreshApplicationDeployment(token, refreshParams).blockAndHandleError()
+        applicationService.refreshApplicationDeployment(token, refreshParams).blockWithTimeout()
 
-    private fun <T> Mono<T>.wait() = this.blockNonNullAndHandleError(Duration.ofSeconds(30))
+    private fun <T> Mono<T>.blockNonNullWithTimeout() = this.blockNonNullAndHandleError(Duration.ofSeconds(30))
+    private fun <T> Mono<T>.blockWithTimeout() = this.blockAndHandleError(Duration.ofSeconds(30))
 }
 
 @Service

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/applicationdeployment/applicationDeploymentResolvers.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/applicationdeployment/applicationDeploymentResolvers.kt
@@ -4,7 +4,6 @@ import com.coxautodev.graphql.tools.GraphQLMutationResolver
 import com.coxautodev.graphql.tools.GraphQLQueryResolver
 import com.coxautodev.graphql.tools.GraphQLResolver
 import graphql.schema.DataFetchingEnvironment
-import no.skatteetaten.aurora.gobo.integration.mokey.ApplicationService
 import no.skatteetaten.aurora.gobo.integration.mokey.ApplicationServiceBlocking
 import no.skatteetaten.aurora.gobo.resolvers.affiliation.Affiliation
 import no.skatteetaten.aurora.gobo.resolvers.application.Application
@@ -42,7 +41,7 @@ class ApplicationDeploymentMutationResolver(
 
 @Component
 class ApplicationDeploymentResolver(
-    private val applicationService: ApplicationService
+    private val applicationService: ApplicationServiceBlocking
 ) : GraphQLResolver<ApplicationDeployment> {
 
     fun affiliation(applicationDeployment: ApplicationDeployment): Affiliation =
@@ -55,8 +54,7 @@ class ApplicationDeploymentResolver(
         dfe.loader(ApplicationDeploymentDetails::class).load(applicationDeployment.id)
 
     fun application(applicationDeployment: ApplicationDeployment): Application? {
-        return applicationService.getApplication(applicationDeployment.applicationId)
-            .map { createApplicationEdge(it).node }
-            .block()
+        val application = applicationService.getApplication(applicationDeployment.applicationId)
+        return createApplicationEdge(application).node
     }
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/resolvers.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/resolvers.kt
@@ -39,13 +39,13 @@ fun <T> Mono<T>.blockAndHandleError(duration: Duration = Duration.ofSeconds(30))
     this.doOnError { handleResponseException(it) }
         .block(duration)
 
-private fun handleResponseException(it: Throwable?) {
-    if (it is WebClientResponseException) {
+private fun handleResponseException(t: Throwable?) {
+    if (t is WebClientResponseException) {
         throw SourceSystemException(
-            "Error in response, status:${it.statusCode} message:${it.statusText}",
-            it,
-            it.responseBodyAsString
+            "Error in response, status:${t.statusCode} message:${t.statusText}",
+            t,
+            t.responseBodyAsString
         )
     }
-    throw SourceSystemException("Error response", it)
+    throw SourceSystemException("Error response", t)
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/resolvers.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/resolvers.kt
@@ -33,8 +33,11 @@ fun <T : Any> DataFetchingEnvironment.loader(type: KClass<T>): DataLoader<Any, T
 
 fun <T> Mono<T>.blockNonNullAndHandleError(duration: Duration = Duration.ofSeconds(30)) =
     this.switchIfEmpty(SourceSystemException("Empty response").toMono())
-        .doOnError { handleResponseException(it) }
-        .block(duration)!!
+        .blockAndHandleError(duration)!!
+
+fun <T> Mono<T>.blockAndHandleError(duration: Duration = Duration.ofSeconds(30)) =
+    this.doOnError { handleResponseException(it) }
+        .block(duration)
 
 private fun handleResponseException(it: Throwable?) {
     if (it is WebClientResponseException) {

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/resolvers.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/resolvers.kt
@@ -44,7 +44,7 @@ private fun handleResponseException(it: Throwable?) {
         throw SourceSystemException(
             "Error in response, status:${it.statusCode} message:${it.statusText}",
             it,
-            it.statusText
+            it.responseBodyAsString
         )
     }
     throw SourceSystemException("Error response", it)

--- a/src/main/resources/schema/applicationdeploymentdetails.graphqls
+++ b/src/main/resources/schema/applicationdeploymentdetails.graphqls
@@ -14,7 +14,7 @@ type PodResource {
   restartCount: Int
   ready: Boolean
   startTime: DateTime
-  links(names: [String]): [Link],
+  links(names: [String]): [Link]
   managementResponses: ManagementResponses
 }
 

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/integration/unclematt/ProbeFirewallTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/integration/unclematt/ProbeFirewallTest.kt
@@ -1,12 +1,13 @@
 package no.skatteetaten.aurora.gobo.integration.unclematt
 
 import assertk.assert
+import assertk.assertions.hasMessageContaining
 import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
 import no.skatteetaten.aurora.gobo.integration.SourceSystemException
 import no.skatteetaten.aurora.gobo.integration.execute
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.springframework.web.reactive.function.client.WebClient
 
 class ProbeFireWallTest {
@@ -25,10 +26,13 @@ class ProbeFireWallTest {
 
     @Test
     fun `throws correct exception when backend returns 404`() {
-        server.execute(404, "") {
-            assertThrows<SourceSystemException> {
+        assert {
+            server.execute(404, "") {
                 probeService.probeFirewall("server.test.no", 9999)
             }
+        }.thrownError {
+            isInstanceOf(SourceSystemException::class)
+            hasMessageContaining("404")
         }
     }
 }

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/service/ApplicationUpgradeServiceTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/service/ApplicationUpgradeServiceTest.kt
@@ -40,7 +40,7 @@ class ApplicationUpgradeServiceTest {
             applicationFileResponse(),
             patchResponse(),
             redeployResponse(),
-            enqueueRefreshResponse()
+            refreshResponse()
         ) {
             upgradeService.upgrade("token", "applicationDeploymentId", "version")
         }
@@ -85,5 +85,5 @@ class ApplicationUpgradeServiceTest {
 
     private fun redeployResponse() = Response(items = listOf(TextNode("{}")))
 
-    private fun enqueueRefreshResponse() = Response(items = listOf(TextNode("{}")))
+    private fun refreshResponse() = Response(items = listOf(TextNode("{}")))
 }

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/service/ApplicationUpgradeServiceTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/service/ApplicationUpgradeServiceTest.kt
@@ -1,6 +1,7 @@
 package no.skatteetaten.aurora.gobo.service
 
 import assertk.assert
+import assertk.assertions.hasMessageContaining
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import com.fasterxml.jackson.databind.node.TextNode
@@ -67,6 +68,20 @@ class ApplicationUpgradeServiceTest {
         }.thrownError {
             server.takeRequest()
             isInstanceOf(SourceSystemException::class)
+        }
+    }
+
+    @Test
+    fun `Handle error response from AuroraConfigService`() {
+        assert {
+            server.execute(404, "Not found") {
+                upgradeService.upgrade("token", "applicationDeploymentId", "version")
+            }
+        }.thrownError {
+            server.takeRequest()
+            isInstanceOf(SourceSystemException::class)
+            hasMessageContaining("404")
+            hasMessageContaining("Not Found")
         }
     }
 


### PR DESCRIPTION
- Handle errors in `resolvers.kt` `handleResponseException`. Removed all the error handling in the integration services. The services can still handle specific response codes by using `.onStatus()`
- All callers of `blockNonNullAndHandleError` and `blockAndHandleError` now handle the timeout. Using a setup like this: `private fun <T> Mono<T>.blockNonNullWithTimeout() = this.blockNonNullAndHandleError(Duration.ofSeconds(30))`. If needed, we can easily move this into a property.
- Created unit test for many different failure scenarios in webclient (`ApplicationUpgradeServiceTest Handle exception from AuroraConfigService`). The two situations we do not handle are: 1) NO_RESPONSE, this is simply due to slowing down the tests, and 2) STALL_SOCKET_AT_START, this is not working and causes the test to never finish. Not sure how to configure webclient to handle this scenario.
