### PR TITLE
unit test tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,16 @@ Quickly deploy to test environment (fish shell):
 
     ./gradlew clean build -x test;
     oc start-build gobo --from-file=(ls build/distributions/gobo-*-Leveransepakke.zip) --wait -n paas-mokey
+    
+
+## Filter tests
+
+There are two tasks in the gradle script that can filter the tests: `testExclude` and `testOnly`  
+By passing tags it is possible to exclude or only run the specified test tags.
+For example to skip the graphql and MockWebServer tests run the following command:  
+`./gradlew testExclude -Ptags=graphql,mockwebserver`  
+
+Tags:
+* **graphql**, tests for the graphql resolvers
+* **spring**, tests using the spring container
+* **mockwebserver**, tests using [MockWebServer](https://github.com/square/okhttp/tree/master/mockwebserver)

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ Quickly deploy to test environment (fish shell):
 ## Filter tests
 
 There are two tasks in the gradle script that can filter the tests: `testExclude` and `testOnly`  
-By passing tags it is possible to exclude or only run the specified test tags.
+By passing tags it is possible to exclude or only run the specified test tags.  
 For example to skip the graphql and MockWebServer tests run the following command:  
-`./gradlew testExclude -Ptags=graphql,mockwebserver`  
+
+    ./gradlew testExclude -Ptags=graphql,mockwebserver 
 
 Tags:
 * **graphql**, tests for the graphql resolvers

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,6 @@ buildscript {
     }
   }
 
-
-
   repositories repos
 
   dependencies {
@@ -26,9 +24,9 @@ plugins {
 }
 
 ext.aurora = [
-    requireStaging   : false,
-    applyCheckstylePlugin: false,
-    applySpockSupport: false,
+    requireStaging          : false,
+    applyCheckstylePlugin   : false,
+    applySpockSupport       : false,
     setProjectVersionFromGit: false
 ]
 
@@ -42,7 +40,7 @@ repositories repos
 [bootJar, distTar, bootDistTar, bootDistZip]*.enabled = false
 configurations.archives.artifacts.removeIf { !it.archiveTask.enabled }
 
-group = groupId 
+group = groupId
 
 dependencyManagement {
   imports {
@@ -81,10 +79,13 @@ dependencies {
       'com.willowtreeapps.assertk:assertk-jvm:0.12',
       'org.springframework.cloud:spring-cloud-starter-contract-stub-runner',
       'org.springframework.security:spring-security-test',
-      'io.projectreactor:reactor-test'
-  ].each { testCompile(it) { 
-    exclude group: 'junit'
-  }}
+      'io.projectreactor:reactor-test',
+      'com.nhaarman:mockito-kotlin:1.6.0'
+  ].each {
+    testCompile(it) {
+      exclude group: 'junit'
+    }
+  }
 
   testImplementation(
       'org.junit.jupiter:junit-jupiter-api',
@@ -120,6 +121,27 @@ compileTestKotlin {
 test {
   useJUnitPlatform()
 }
+
+//noinspection GroovyAssignabilityCheck
+task testExclude(type: Test) {
+  if (project.hasProperty('tags')) {
+    useJUnitPlatform {
+      excludeTags tags.split(',')
+    }
+  } else {
+    useJUnitPlatform()
+  }
+}
+
+//noinspection GroovyAssignabilityCheck
+task testOnly(type: Test) {
+  if (project.hasProperty('tags')) {
+    useJUnitPlatform {
+      includeTags tags.split(',')
+    }
+  }
+}
+
 task wrapper(type: Wrapper) {
   gradleVersion = '4.7'
 }

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/GraphQLTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/GraphQLTest.kt
@@ -1,10 +1,16 @@
 package no.skatteetaten.aurora.gobo
 
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Tags
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.junit.jupiter.SpringExtension
 
+@Tags(
+    Tag("graphql"),
+    Tag("spring")
+)
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = ["management.server.port=-1"])
 @DirtiesContext

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/integration/boober/UserSettingsServiceTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/integration/boober/UserSettingsServiceTest.kt
@@ -3,6 +3,7 @@ package no.skatteetaten.aurora.gobo.integration.boober
 import assertk.assert
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
+import no.skatteetaten.aurora.gobo.integration.MockWebServerTestTag
 import no.skatteetaten.aurora.gobo.integration.Response
 import no.skatteetaten.aurora.gobo.integration.execute
 import no.skatteetaten.aurora.gobo.resolvers.usersettings.ApplicationDeploymentFilter
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.HttpMethod
 import org.springframework.web.reactive.function.client.WebClient
 
+@MockWebServerTestTag
 class UserSettingsServiceTest {
 
     private val server = MockWebServer()

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/integration/dbh/DatabaseSchemaServiceBlockingTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/integration/dbh/DatabaseSchemaServiceBlockingTest.kt
@@ -12,6 +12,7 @@ import assertk.catch
 import io.mockk.every
 import io.mockk.mockk
 import no.skatteetaten.aurora.gobo.DatabaseSchemaResourceBuilder
+import no.skatteetaten.aurora.gobo.integration.MockWebServerTestTag
 import no.skatteetaten.aurora.gobo.integration.Response
 import no.skatteetaten.aurora.gobo.integration.SourceSystemException
 import no.skatteetaten.aurora.gobo.integration.execute
@@ -20,6 +21,7 @@ import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.Test
 import org.springframework.web.reactive.function.client.WebClient.create
 
+@MockWebServerTestTag
 class DatabaseSchemaServiceBlockingTest {
     private val server = MockWebServer()
     private val sharedSecretReader = mockk<SharedSecretReader> {

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/integration/imageregistry/ImageRegistryServiceBlockingTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/integration/imageregistry/ImageRegistryServiceBlockingTest.kt
@@ -9,6 +9,7 @@ import assertk.assertions.message
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
+import no.skatteetaten.aurora.gobo.integration.MockWebServerTestTag
 import no.skatteetaten.aurora.gobo.integration.execute
 import no.skatteetaten.aurora.gobo.integration.imageregistry.AuthenticationMethod.KUBERNETES_TOKEN
 import no.skatteetaten.aurora.gobo.integration.imageregistry.AuthenticationMethod.NONE
@@ -22,6 +23,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.web.reactive.function.client.WebClient
 import java.time.Instant
 
+@MockWebServerTestTag
 class ImageRegistryServiceBlockingTest {
 
     private val imageRepoName = "no_skatteetaten_aurora/boober"

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/integration/mokey/AffiliationServiceBlockingTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/integration/mokey/AffiliationServiceBlockingTest.kt
@@ -3,6 +3,7 @@ package no.skatteetaten.aurora.gobo.integration.mokey
 import assertk.assert
 import assertk.assertions.contains
 import assertk.assertions.isNotEmpty
+import no.skatteetaten.aurora.gobo.integration.SpringTestTag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -10,6 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.cloud.contract.stubrunner.spring.AutoConfigureStubRunner
 import org.springframework.test.context.junit.jupiter.SpringExtension
 
+@SpringTestTag
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @AutoConfigureStubRunner

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/integration/mokey/ApplicationServiceBlockingTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/integration/mokey/ApplicationServiceBlockingTest.kt
@@ -3,6 +3,7 @@ package no.skatteetaten.aurora.gobo.integration.mokey
 import assertk.assert
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
+import no.skatteetaten.aurora.gobo.integration.SpringTestTag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -10,6 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.cloud.contract.stubrunner.spring.AutoConfigureStubRunner
 import org.springframework.test.context.junit.jupiter.SpringExtension
 
+@SpringTestTag
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @AutoConfigureStubRunner

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/integration/testTags.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/integration/testTags.kt
@@ -1,0 +1,9 @@
+package no.skatteetaten.aurora.gobo.integration
+
+import org.junit.jupiter.api.Tag
+
+@Tag("mockwebserver")
+annotation class MockWebServerTestTag
+
+@Tag("spring")
+annotation class SpringTestTag

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/integration/unclematt/ProbeFirewallTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/integration/unclematt/ProbeFirewallTest.kt
@@ -7,12 +7,14 @@ import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
 import assertk.assertions.message
 import assertk.catch
+import no.skatteetaten.aurora.gobo.integration.MockWebServerTestTag
 import no.skatteetaten.aurora.gobo.integration.SourceSystemException
 import no.skatteetaten.aurora.gobo.integration.execute
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.Test
 import org.springframework.web.reactive.function.client.WebClient
 
+@MockWebServerTestTag
 class ProbeFireWallTest {
 
     private val server = MockWebServer()

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/resolvers/applicationdeploymentdetails/ApplicationDeploymentDetailsDataLoaderTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/resolvers/applicationdeploymentdetails/ApplicationDeploymentDetailsDataLoaderTest.kt
@@ -5,6 +5,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isSameAs
 import no.skatteetaten.aurora.gobo.ApplicationDeploymentDetailsBuilder
+import no.skatteetaten.aurora.gobo.integration.MockWebServerTestTag
 import no.skatteetaten.aurora.gobo.integration.execute
 import no.skatteetaten.aurora.gobo.integration.mokey.ApplicationService
 import no.skatteetaten.aurora.gobo.integration.mokey.ApplicationServiceBlocking
@@ -17,6 +18,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.web.reactive.function.client.WebClient
 
+@MockWebServerTestTag
 class ApplicationDeploymentDetailsDataLoaderTest {
 
     private val server = MockWebServer()

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/service/ApplicationUpgradeServiceTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/service/ApplicationUpgradeServiceTest.kt
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.node.TextNode
 import no.skatteetaten.aurora.gobo.ApplicationConfig
 import no.skatteetaten.aurora.gobo.ApplicationDeploymentDetailsBuilder
 import no.skatteetaten.aurora.gobo.AuroraConfigFileBuilder
+import no.skatteetaten.aurora.gobo.integration.MockWebServerTestTag
 import no.skatteetaten.aurora.gobo.integration.Response
 import no.skatteetaten.aurora.gobo.integration.SourceSystemException
 import no.skatteetaten.aurora.gobo.integration.boober.AuroraConfigService
@@ -25,6 +26,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.hateoas.Link
 
+@MockWebServerTestTag
 class ApplicationUpgradeServiceTest {
 
     private val server = MockWebServer()


### PR DESCRIPTION
Added `testExclude` and `testOnly` gradle tasks to filter tests. This makes it easy to for example skip slow tests.