### PR TITLE
AOS-3189 log queries + update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,8 @@ Tags:
 * **graphql**, tests for the graphql resolvers
 * **spring**, tests using the spring container
 * **mockwebserver**, tests using [MockWebServer](https://github.com/square/okhttp/tree/master/mockwebserver)
+
+
+## GraphQL tracing
+
+To enable tracing: `gobo.graphql.tracing-enabled=true`

--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,9 @@ buildscript {
 }
 
 plugins {
-  id 'org.jetbrains.kotlin.jvm' version '1.3.11'
-  id 'org.jetbrains.kotlin.plugin.spring' version '1.3.11'
-  id 'org.springframework.boot' version '2.0.6.RELEASE'
+  id 'org.jetbrains.kotlin.jvm' version '1.3.21'
+  id 'org.jetbrains.kotlin.plugin.spring' version '1.3.21'
+  id 'org.springframework.boot' version '2.1.2.RELEASE'
   id 'org.jlleitschuh.gradle.ktlint' version '6.3.0'
 }
 
@@ -44,7 +44,7 @@ group = groupId
 
 dependencyManagement {
   imports {
-    mavenBom "org.springframework.cloud:spring-cloud-contract-dependencies:2.1.0.RC3"
+    mavenBom "org.springframework.cloud:spring-cloud-contract-dependencies:2.1.0.RELEASE"
   }
 }
 
@@ -52,21 +52,21 @@ def junitJupiterVersion = dependencyManagement.importedProperties['junit-jupiter
 dependencies {
 
   compile(
-      'org.jetbrains.kotlin:kotlin-reflect:1.3.11',
+      'org.jetbrains.kotlin:kotlin-reflect:1.3.21',
       'org.jetbrains.kotlin:kotlin-stdlib-jdk8',
       'com.fasterxml.jackson.module:jackson-module-kotlin',
       'com.fasterxml.jackson.datatype:jackson-datatype-jsr310',
       'no.skatteetaten.aurora.springboot:aurora-spring-boot2-starter:1.2.6',
-      'io.fabric8:openshift-client:4.1.0',
+      'io.fabric8:openshift-client:4.1.1',
       'com.fkorotkov:kubernetes-dsl:1.2.1',
       "org.springframework.retry:spring-retry",
       'org.springframework.boot:spring-boot-starter-webflux',
       'org.springframework.boot:spring-boot-starter-security',
-      'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0',
+      'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.1',
       'org.springframework.boot:spring-boot-starter-hateoas',
-      'com.graphql-java-kickstart:graphql-spring-boot-starter:5.0.5',
-      'com.graphql-java-kickstart:graphiql-spring-boot-starter:5.0.5',
-      'com.graphql-java-kickstart:graphql-java-tools:5.3.4',
+      'com.graphql-java-kickstart:graphql-spring-boot-starter:5.4.1',
+      'com.graphql-java-kickstart:graphiql-spring-boot-starter:5.4.1',
+      'com.graphql-java-kickstart:graphql-java-tools:5.4.1',
       'com.github.fge:json-patch:1.9',
       'org.springframework.boot:spring-boot-devtools'
   )
@@ -89,7 +89,7 @@ dependencies {
 
   testImplementation(
       'org.junit.jupiter:junit-jupiter-api',
-      'com.squareup.okhttp3:mockwebserver:3.10.0',
+      'com.squareup.okhttp3:mockwebserver:3.13.1',
       'io.mockk:mockk:1.9',
       'net.bytebuddy:byte-buddy:1.9.3',
       'net.bytebuddy:byte-buddy-agent:1.9.3'

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/GraphQLConfig.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/GraphQLConfig.kt
@@ -5,8 +5,11 @@ import com.oembedler.moon.graphql.boot.GraphQLWebAutoConfiguration
 import graphql.execution.AsyncExecutionStrategy
 import graphql.execution.ExecutionStrategy
 import graphql.execution.SubscriptionExecutionStrategy
+import graphql.execution.instrumentation.Instrumentation
+import graphql.execution.instrumentation.tracing.TracingInstrumentation
 import no.skatteetaten.aurora.gobo.resolvers.errorhandling.GoboDataFetcherExceptionHandler
 import org.dataloader.Try
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -22,9 +25,15 @@ class GraphQLConfig {
 
     @Bean
     fun executionStrategies(): Map<String, ExecutionStrategy> =
-            mapOf(
-                    GraphQLWebAutoConfiguration.QUERY_EXECUTION_STRATEGY to AsyncExecutionStrategy(GoboDataFetcherExceptionHandler()),
-                    GraphQLWebAutoConfiguration.MUTATION_EXECUTION_STRATEGY to AsyncExecutionStrategy(),
-                    GraphQLWebAutoConfiguration.SUBSCRIPTION_EXECUTION_STRATEGY to SubscriptionExecutionStrategy()
-            )
+        mapOf(
+            GraphQLWebAutoConfiguration.QUERY_EXECUTION_STRATEGY to AsyncExecutionStrategy(
+                GoboDataFetcherExceptionHandler()
+            ),
+            GraphQLWebAutoConfiguration.MUTATION_EXECUTION_STRATEGY to AsyncExecutionStrategy(),
+            GraphQLWebAutoConfiguration.SUBSCRIPTION_EXECUTION_STRATEGY to SubscriptionExecutionStrategy()
+        )
+
+    @Bean
+    @ConditionalOnProperty(name = ["gobo.graphql.tracing-enabled"], havingValue = "true", matchIfMissing = false)
+    fun tracingInstrumentation(): Instrumentation = TracingInstrumentation()
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/affiliation/affiliation.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/affiliation/affiliation.kt
@@ -1,13 +1,12 @@
 package no.skatteetaten.aurora.gobo.resolvers.affiliation
 
-import graphql.relay.DefaultEdge
-import graphql.relay.PageInfo
-import no.skatteetaten.aurora.gobo.resolvers.Connection
-import no.skatteetaten.aurora.gobo.resolvers.Cursor
+import no.skatteetaten.aurora.gobo.resolvers.GoboConnection
+import no.skatteetaten.aurora.gobo.resolvers.GoboEdge
+import no.skatteetaten.aurora.gobo.resolvers.GoboPageInfo
 
 data class Affiliation(val name: String)
 
-data class AffiliationEdge(private val node: Affiliation) : DefaultEdge<Affiliation>(node, Cursor(node.name))
+data class AffiliationEdge(val node: Affiliation) : GoboEdge(node.name)
 
-data class AffiliationsConnection(override val edges: List<AffiliationEdge>, override val pageInfo: PageInfo?) :
-    Connection<AffiliationEdge>()
+data class AffiliationsConnection(override val edges: List<AffiliationEdge>, override val pageInfo: GoboPageInfo?) :
+    GoboConnection<AffiliationEdge>()

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/application/application.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/application/application.kt
@@ -1,10 +1,9 @@
 package no.skatteetaten.aurora.gobo.resolvers.application
 
-import graphql.relay.DefaultEdge
-import graphql.relay.PageInfo
 import no.skatteetaten.aurora.gobo.integration.mokey.ApplicationResource
-import no.skatteetaten.aurora.gobo.resolvers.Connection
-import no.skatteetaten.aurora.gobo.resolvers.Cursor
+import no.skatteetaten.aurora.gobo.resolvers.GoboConnection
+import no.skatteetaten.aurora.gobo.resolvers.GoboEdge
+import no.skatteetaten.aurora.gobo.resolvers.GoboPageInfo
 import no.skatteetaten.aurora.gobo.resolvers.applicationdeployment.ApplicationDeployment
 import no.skatteetaten.aurora.gobo.resolvers.applicationdeployment.ApplicationDeploymentBuilder
 import no.skatteetaten.aurora.gobo.resolvers.createPageInfo
@@ -15,10 +14,7 @@ data class Application(
     val applicationDeployments: List<ApplicationDeployment>
 )
 
-data class ApplicationEdge(private val node: Application) : DefaultEdge<Application>(
-    node,
-    Cursor(node.name)
-) {
+data class ApplicationEdge(val node: Application) : GoboEdge(node.name) {
     companion object {
         fun create(resource: ApplicationResource, applicationDeployments: List<ApplicationDeployment>) =
             ApplicationEdge(
@@ -33,8 +29,8 @@ data class ApplicationEdge(private val node: Application) : DefaultEdge<Applicat
 
 data class ApplicationsConnection(
     override val edges: List<ApplicationEdge>,
-    override val pageInfo: PageInfo = createPageInfo(edges)
-) : Connection<ApplicationEdge>()
+    override val pageInfo: GoboPageInfo = createPageInfo(edges)
+) : GoboConnection<ApplicationEdge>()
 
 private val deploymentBuilder = ApplicationDeploymentBuilder()
 

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/gobo/GoboQueryResolver.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/gobo/GoboQueryResolver.kt
@@ -1,0 +1,11 @@
+package no.skatteetaten.aurora.gobo.resolvers.gobo
+
+import com.coxautodev.graphql.tools.GraphQLQueryResolver
+import no.skatteetaten.aurora.gobo.resolvers.GoboInstrumentation
+import org.springframework.stereotype.Component
+
+@Component
+class GoboQueryResolver(private val goboInstrumentation: GoboInstrumentation) : GraphQLQueryResolver {
+
+    fun gobo() = Gobo(GoboUsage(goboInstrumentation.fields.names))
+}

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/gobo/goboUsage.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/gobo/goboUsage.kt
@@ -1,0 +1,5 @@
+package no.skatteetaten.aurora.gobo.resolvers.gobo
+
+data class GoboUsage(val usedFields: Set<String>)
+
+data class Gobo(val usage: GoboUsage)

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/graphqlTypes.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/graphqlTypes.kt
@@ -1,15 +1,26 @@
 package no.skatteetaten.aurora.gobo.resolvers
 
-import graphql.relay.DefaultConnectionCursor
-import graphql.relay.PageInfo
 import org.springframework.util.Base64Utils
 
-abstract class Connection<T> {
+abstract class GoboConnection<T> {
     abstract val edges: List<T>
-    abstract val pageInfo: PageInfo?
+    abstract val pageInfo: GoboPageInfo?
 
     open val totalCount: Int
         get() = edges.size
 }
 
-class Cursor(value: String) : DefaultConnectionCursor(Base64Utils.encodeToString(value.toByteArray()))
+class GoboCursor(input: String) {
+    val value: String = Base64Utils.encodeToString(input.toByteArray())
+}
+
+abstract class GoboEdge(name: String) {
+    val cursor = GoboCursor(name)
+}
+
+data class GoboPageInfo(
+    val startCursor: GoboCursor?,
+    val endCursor: GoboCursor?,
+    val hasPreviousPage: Boolean,
+    val hasNextPage: Boolean
+)

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/imagerepository/imagerepository.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/imagerepository/imagerepository.kt
@@ -1,13 +1,12 @@
 package no.skatteetaten.aurora.gobo.resolvers.imagerepository
 
-import graphql.relay.DefaultEdge
-import graphql.relay.PageInfo
-import no.skatteetaten.aurora.gobo.resolvers.Connection
-import no.skatteetaten.aurora.gobo.resolvers.Cursor
-import no.skatteetaten.aurora.gobo.resolvers.PagedEdges
 import no.skatteetaten.aurora.gobo.integration.imageregistry.ImageRepoDto
 import no.skatteetaten.aurora.gobo.integration.imageregistry.ImageTagType
 import no.skatteetaten.aurora.gobo.integration.imageregistry.ImageTagType.Companion.typeOf
+import no.skatteetaten.aurora.gobo.resolvers.GoboConnection
+import no.skatteetaten.aurora.gobo.resolvers.GoboEdge
+import no.skatteetaten.aurora.gobo.resolvers.GoboPageInfo
+import no.skatteetaten.aurora.gobo.resolvers.GoboPagedEdges
 import org.slf4j.LoggerFactory
 
 data class ImageRepository(
@@ -58,14 +57,14 @@ data class ImageTag(
     }
 }
 
-data class ImageTagEdge(private val node: ImageTag) : DefaultEdge<ImageTag>(node, Cursor(node.name))
+data class ImageTagEdge(val node: ImageTag) : GoboEdge(node.name)
 
 data class ImageTagsConnection(
     override val edges: List<ImageTagEdge>,
-    override val pageInfo: PageInfo?,
+    override val pageInfo: GoboPageInfo?,
     override val totalCount: Int = edges.size
-) : Connection<ImageTagEdge>() {
-    constructor(paged: PagedEdges<ImageTagEdge>) : this(paged.edges, paged.pageInfo, paged.totalCount)
+) : GoboConnection<ImageTagEdge>() {
+    constructor(paged: GoboPagedEdges<ImageTagEdge>) : this(paged.edges, paged.pageInfo, paged.totalCount)
 }
 
 fun ImageRepository.toImageRepo() = ImageRepoDto(this.registryUrl, this.namespace, this.name)

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/instrumentation.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/instrumentation.kt
@@ -23,7 +23,7 @@ class GoboInstrumentation : SimpleInstrumentation() {
         executionInput?.let {
             val query = it.query
             if (query.trimStart().startsWith("mutation")) {
-                logger.info("Mutation: $query")
+                logger.info("Mutation: $query - Variable keys: ${it.variables.keys}")
             } else {
                 logger.info("Query: $query - Variables: ${it.variables}")
             }
@@ -37,7 +37,6 @@ class GoboInstrumentation : SimpleInstrumentation() {
     ): ExecutionContext {
         val selectionSet = executionContext?.operationDefinition?.selectionSet ?: SelectionSet(emptyList())
         fields.updateFieldNames(selectionSet)
-
         return super.instrumentExecutionContext(executionContext, parameters)
     }
 }
@@ -45,7 +44,7 @@ class GoboInstrumentation : SimpleInstrumentation() {
 class Fields {
     private val _names: MutableSet<String> = mutableSetOf()
     val names: Set<String>
-        get() = _names.toSet()
+        get() = _names.sorted().toSet()
 
     fun updateFieldNames(selectionSet: SelectionSet?, parent: String? = null) {
         selectionSet?.selections?.map {

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/instrumentation.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/instrumentation.kt
@@ -23,9 +23,9 @@ class GoboInstrumentation : SimpleInstrumentation() {
         executionInput?.let {
             val query = it.query
             if (query.trimStart().startsWith("mutation")) {
-                logger.info("Mutation: $query - Variable keys: ${it.variables.keys}")
+                logger.info("mutation=\"$query\" - variable-keys=${it.variables.keys}")
             } else {
-                logger.info("Query: $query - Variables: ${it.variables}")
+                logger.info("query=\"$query\" - variables=${it.variables}")
             }
         }
         return super.instrumentExecutionInput(executionInput, parameters)

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/instrumentation.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/instrumentation.kt
@@ -1,0 +1,58 @@
+package no.skatteetaten.aurora.gobo.resolvers
+
+import graphql.ExecutionInput
+import graphql.execution.ExecutionContext
+import graphql.execution.instrumentation.SimpleInstrumentation
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
+import graphql.language.Field
+import graphql.language.SelectionSet
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class GoboInstrumentation : SimpleInstrumentation() {
+
+    private val logger = LoggerFactory.getLogger(GoboInstrumentation::class.java)
+
+    val fields = Fields()
+
+    override fun instrumentExecutionInput(
+        executionInput: ExecutionInput?,
+        parameters: InstrumentationExecutionParameters?
+    ): ExecutionInput {
+        executionInput?.let {
+            val query = it.query
+            if (query.trimStart().startsWith("mutation")) {
+                logger.info("Mutation: $query")
+            } else {
+                logger.info("Query: $query - Variables: ${it.variables}")
+            }
+        }
+        return super.instrumentExecutionInput(executionInput, parameters)
+    }
+
+    override fun instrumentExecutionContext(
+        executionContext: ExecutionContext?,
+        parameters: InstrumentationExecutionParameters?
+    ): ExecutionContext {
+        val selectionSet = executionContext?.operationDefinition?.selectionSet ?: SelectionSet(emptyList())
+        fields.updateFieldNames(selectionSet)
+
+        return super.instrumentExecutionContext(executionContext, parameters)
+    }
+}
+
+class Fields {
+    private val _names: MutableSet<String> = mutableSetOf()
+    val names: Set<String>
+        get() = _names.toSet()
+
+    fun updateFieldNames(selectionSet: SelectionSet?, parent: String? = null) {
+        selectionSet?.selections?.map {
+            val name = (it as Field).name
+            val fullName = if (parent == null) name else "$parent.$name"
+            _names.add(fullName)
+            updateFieldNames(it.selectionSet, fullName)
+        }
+    }
+}

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/instrumentation.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/instrumentation.kt
@@ -48,10 +48,11 @@ class Fields {
 
     fun updateFieldNames(selectionSet: SelectionSet?, parent: String? = null) {
         selectionSet?.selections?.map {
-            val name = (it as Field).name
-            val fullName = if (parent == null) name else "$parent.$name"
-            _names.add(fullName)
-            updateFieldNames(it.selectionSet, fullName)
+            if (it is Field) {
+                val fullName = if (parent == null) it.name else "$parent.${it.name}"
+                _names.add(fullName)
+                updateFieldNames(it.selectionSet, fullName)
+            }
         }
     }
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/paging.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/paging.kt
@@ -1,20 +1,17 @@
 package no.skatteetaten.aurora.gobo.resolvers
 
-import graphql.relay.DefaultEdge
-import graphql.relay.DefaultPageInfo
-import graphql.relay.PageInfo
 import java.lang.Math.min
 
-data class PagedEdges<T>(val edges: List<T>, val pageInfo: PageInfo, val totalCount: Int)
+data class GoboPagedEdges<T>(val edges: List<T>, val pageInfo: GoboPageInfo, val totalCount: Int)
 
-fun <T : DefaultEdge<*>> pageEdges(allEdges: List<T>, first: Int? = null, after: String? = null): PagedEdges<T> {
+fun <T : GoboEdge> pageEdges(allEdges: List<T>, first: Int? = null, after: String? = null): GoboPagedEdges<T> {
 
     val edges = createPage(allEdges, first, after)
     val pageInfo = createPageInfo(edges, allEdges)
-    return PagedEdges(edges, pageInfo, allEdges.size)
+    return GoboPagedEdges(edges, pageInfo, allEdges.size)
 }
 
-private fun <T : DefaultEdge<*>> createPage(edges: List<T>, first: Int?, afterCursor: String?): List<T> {
+private fun <T : GoboEdge> createPage(edges: List<T>, first: Int?, afterCursor: String?): List<T> {
     val startIndex = if (afterCursor != null) edges.indexOfFirst { it.cursor.value == afterCursor } + 1 else 0
     return createPage(edges, startIndex, first ?: edges.size)
 }
@@ -24,9 +21,9 @@ fun <T> createPage(edges: List<T>, offset: Int, limit: Int = edges.size): List<T
     return edges.subList(offset, endIndex)
 }
 
-fun <T : DefaultEdge<*>> createPageInfo(pageEdges: List<T>, allEdges: List<T> = pageEdges): DefaultPageInfo {
+fun <T : GoboEdge> createPageInfo(pageEdges: List<T>, allEdges: List<T> = pageEdges): GoboPageInfo {
 
-    data class Cursors<T : DefaultEdge<*>>(private val edges: List<T>) {
+    data class Cursors<T : GoboEdge>(private val edges: List<T>) {
         val first get() = edges.firstOrNull()?.cursor
         val last get() = edges.lastOrNull()?.cursor
 
@@ -36,5 +33,5 @@ fun <T : DefaultEdge<*>> createPageInfo(pageEdges: List<T>, allEdges: List<T> = 
 
     val page = Cursors(pageEdges)
     val all = Cursors(allEdges)
-    return DefaultPageInfo(page.first, page.last, page.isAtStartOf(all), page.isAtEndOf(all))
+    return GoboPageInfo(page.first, page.last, page.isAtStartOf(all), page.isAtEndOf(all))
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,6 +16,9 @@ gobo:
         url: http://boober
     unclematt:
         url: http://unclematt-aurora-daemons.utv.paas.skead.no
+    graphql:
+        tracing-enabled: false
+
 aurora:
     starter:
         headerfilter:

--- a/src/main/resources/schema/gobo.graphqls
+++ b/src/main/resources/schema/gobo.graphqls
@@ -1,0 +1,7 @@
+type GoboUsage {
+  usedFields: [String]!
+}
+
+type Gobo {
+  usage: GoboUsage!
+}

--- a/src/main/resources/schema/root.graphqls
+++ b/src/main/resources/schema/root.graphqls
@@ -3,24 +3,16 @@ scalar URL
 
 type Query {
   affiliations(name: String, checkForVisibility: Boolean): AffiliationsConnection
-
   applications(affiliations: [String!]!, applications: [String!]): ApplicationsConnection
-
   applicationDeployment(id: String!): ApplicationDeployment
-
   applicationDeploymentDetails(id: String!): ApplicationDeploymentDetails
-
   imageRepositories(repositories: [String!]): [ImageRepository!]
-
   currentUser: User
-
   scan(host: String!, port: Int = 80): Scan
-
   userSettings: UserSettings
-
   databaseSchemas(affiliations: [String!]!): [DatabaseSchema!]
-
   databaseSchema(id: String!): DatabaseSchema
+  gobo: Gobo
 }
 
 type Mutation {

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/PagingTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/PagingTest.kt
@@ -5,9 +5,9 @@ import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isNull
-import graphql.relay.DefaultEdge
-import no.skatteetaten.aurora.gobo.resolvers.Cursor
-import no.skatteetaten.aurora.gobo.resolvers.PagedEdges
+import no.skatteetaten.aurora.gobo.resolvers.GoboCursor
+import no.skatteetaten.aurora.gobo.resolvers.GoboEdge
+import no.skatteetaten.aurora.gobo.resolvers.GoboPagedEdges
 import no.skatteetaten.aurora.gobo.resolvers.pageEdges
 import org.junit.jupiter.api.Test
 
@@ -32,8 +32,8 @@ class PagingTest {
             val pageInfo = pagedEdges.pageInfo
             assertThat(pageInfo.startCursor).isNull()
             assertThat(pageInfo.endCursor).isNull()
-            assertThat(pageInfo.isHasNextPage).isFalse()
-            assertThat(pageInfo.isHasPreviousPage).isFalse()
+            assertThat(pageInfo.hasNextPage).isFalse()
+            assertThat(pageInfo.hasPreviousPage).isFalse()
         }
     }
 
@@ -69,14 +69,14 @@ class PagingTest {
         hasNexPage = true
     )
 
-    data class Edge(private val node: String) : DefaultEdge<String>(node, Cursor(node))
+    data class Edge(val node: String) : GoboEdge(node)
 
     companion object {
         val edges = toEdges("A", "B", "C", "D", "E")
         fun toEdges(vararg names: String) = names.map { Edge(it) }
-        fun cursorOf(s: String): String = Cursor(s).value
+        fun cursorOf(s: String): String = GoboCursor(s).value
         fun verify(
-            pageEdges: PagedEdges<Edge>,
+            pageEdges: GoboPagedEdges<Edge>,
             expectedEdges: List<Edge>,
             hasPrevPage: Boolean,
             hasNexPage: Boolean
@@ -88,10 +88,10 @@ class PagingTest {
 
             assertThat(edges.size).isEqualTo(expectedEdges.size)
             assertThat(edges).isEqualTo(expectedEdges)
-            assertThat(pageInfo.isHasPreviousPage).isEqualTo(hasPrevPage)
-            assertThat(pageInfo.isHasNextPage).isEqualTo(hasNexPage)
-            assertThat(pageInfo.startCursor.value).isEqualTo(expectedEdges.first().cursor.value)
-            assertThat(pageInfo.endCursor.value).isEqualTo(expectedEdges.last().cursor.value)
+            assertThat(pageInfo.hasPreviousPage).isEqualTo(hasPrevPage)
+            assertThat(pageInfo.hasNextPage).isEqualTo(hasNexPage)
+            assertThat(pageInfo.startCursor?.value).isEqualTo(expectedEdges.first().cursor.value)
+            assertThat(pageInfo.endCursor?.value).isEqualTo(expectedEdges.last().cursor.value)
         }
     }
 }

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/integration/imageregistry/DefaultRegistryMetadataResolverTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/integration/imageregistry/DefaultRegistryMetadataResolverTest.kt
@@ -28,4 +28,13 @@ class DefaultRegistryMetadataResolverTest {
         assertThat(metadata.apiSchema).isEqualTo("https")
         assertThat(metadata.authenticationMethod).isEqualTo(NONE)
     }
+
+    @Test
+    fun `verify metadata for internal IP`() {
+        val metadata = metadataResolver.getMetadataForRegistry("127.0.0.1:5000")
+
+        assertThat(metadata.apiSchema).isEqualTo("http")
+        assertThat(metadata.authenticationMethod).isEqualTo(KUBERNETES_TOKEN)
+        assertThat(metadata.isInternal).isEqualTo(true)
+    }
 }

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/resolvers/FieldsTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/resolvers/FieldsTest.kt
@@ -1,0 +1,23 @@
+package no.skatteetaten.aurora.gobo.resolvers
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.hasSize
+import graphql.language.Field
+import graphql.language.SelectionSet
+import org.junit.jupiter.api.Test
+
+class FieldsTest {
+    private val fields = Fields()
+
+    @Test
+    fun `Get field name from SelectionSet`() {
+        val id = SelectionSet.newSelectionSet().selections(listOf(Field("id"), Field("id"))).build()
+        val databaseSchema = SelectionSet.newSelectionSet().selections(listOf(Field("databaseSchema", id))).build()
+        fields.updateFieldNames(databaseSchema)
+
+        assertThat(fields.names).hasSize(2)
+        assertThat(fields.names).contains("databaseSchema")
+        assertThat(fields.names).contains("databaseSchema.id")
+    }
+}

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/resolvers/GoboInstrumentationTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/resolvers/GoboInstrumentationTest.kt
@@ -1,0 +1,39 @@
+package no.skatteetaten.aurora.gobo.resolvers
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.hasSize
+import graphql.execution.ExecutionContextBuilder
+import graphql.execution.ExecutionId
+import graphql.language.Field
+import graphql.language.OperationDefinition
+import graphql.language.SelectionSet
+import org.junit.jupiter.api.Test
+
+class GoboInstrumentationTest {
+
+    private val goboInstrumentation = GoboInstrumentation()
+
+    @Test
+    fun `Find field names from ExecutionContext`() {
+        val selectionSet = SelectionSet.newSelectionSet().selections(listOf(Field("id"))).build()
+        val operationDefinition = OperationDefinition.newOperationDefinition().selectionSet(selectionSet).build()
+        val executionContext =
+            ExecutionContextBuilder.newExecutionContextBuilder()
+                .executionId(ExecutionId.from("123"))
+                .operationDefinition(operationDefinition).build()
+        goboInstrumentation.instrumentExecutionContext(executionContext, null)
+        assertThat(goboInstrumentation.fields.names).hasSize(1)
+        assertThat(goboInstrumentation.fields.names).contains("id")
+    }
+
+    @Test
+    fun `No field names found when SelectionSet is empty in ExecutionContext`() {
+        val executionContext =
+            ExecutionContextBuilder()
+                .executionId(ExecutionId.from("123"))
+                .operationDefinition(OperationDefinition.newOperationDefinition().build()).build()
+        goboInstrumentation.instrumentExecutionContext(executionContext, null)
+        assertThat(goboInstrumentation.fields.names).hasSize(0)
+    }
+}

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/resolvers/gobo/GoboQueryResolverTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/resolvers/gobo/GoboQueryResolverTest.kt
@@ -1,0 +1,28 @@
+package no.skatteetaten.aurora.gobo.resolvers.gobo
+
+import no.skatteetaten.aurora.gobo.GraphQLTest
+import no.skatteetaten.aurora.gobo.resolvers.graphqlData
+import no.skatteetaten.aurora.gobo.resolvers.queryGraphQL
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.io.Resource
+import org.springframework.test.web.reactive.server.WebTestClient
+
+@GraphQLTest
+class GoboQueryResolverTest {
+
+    @Value("classpath:graphql/queries/getGoboUsage.graphql")
+    private lateinit var getGoboUsageQuery: Resource
+
+    @Autowired
+    private lateinit var webTestClient: WebTestClient
+
+    @Test
+    fun `Get Gobo usage`() {
+        webTestClient.queryGraphQL(getGoboUsageQuery)
+            .expectStatus().isOk
+            .expectBody()
+            .graphqlData("gobo.usage.usedFields").isNotEmpty
+    }
+}

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/resolvers/imagerepository/ImageRepositoryQueryResolverTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/resolvers/imagerepository/ImageRepositoryQueryResolverTest.kt
@@ -3,13 +3,15 @@ package no.skatteetaten.aurora.gobo.resolvers.imagerepository
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
-import assertk.assertions.isNotEmpty
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.isNotNull
 import assertk.assertions.isTrue
 import no.skatteetaten.aurora.gobo.GraphQLTest
 import no.skatteetaten.aurora.gobo.integration.SourceSystemException
 import no.skatteetaten.aurora.gobo.integration.imageregistry.ImageRegistryServiceBlocking
 import no.skatteetaten.aurora.gobo.integration.imageregistry.ImageRepoDto
 import no.skatteetaten.aurora.gobo.integration.imageregistry.ImageTagDto
+import no.skatteetaten.aurora.gobo.resolvers.GoboPageInfo
 import no.skatteetaten.aurora.gobo.resolvers.createQuery
 import no.skatteetaten.aurora.gobo.resolvers.graphqlErrors
 import no.skatteetaten.aurora.gobo.resolvers.imagerepository.ImageRepository.Companion.fromRepoString
@@ -107,8 +109,8 @@ class ImageRepositoryQueryResolverTest {
                 assertThat(tags.totalCount).isEqualTo(testData[0].tags.size)
                 assertThat(tags.edges.size).isEqualTo(pageSize)
                 assertThat(tags.edges.map { it.node.name }).containsExactly("1", "1.0", "1.0.0")
-                assertThat(tags.pageInfo!!.startCursor).isNotEmpty()
-                assertThat(tags.pageInfo.hasNextPage).isTrue()
+                assertThat(tags.pageInfo?.startCursor).isNotEqualTo("")
+                assertThat(tags.pageInfo?.hasNextPage).isNotNull().isTrue()
             }
     }
 
@@ -129,10 +131,9 @@ class ImageRepositoryQueryResolverTest {
 }
 
 class QueryResponse {
-    data class PageInfo(val startCursor: String, val hasNextPage: Boolean)
     data class Tag(val name: String, val lastModified: String)
     data class Edge(val node: Tag)
-    data class Tags(val totalCount: Int, val edges: List<Edge>, val pageInfo: PageInfo?)
+    data class Tags(val totalCount: Int, val edges: List<Edge>, val pageInfo: GoboPageInfo?)
     data class ImageRepository(val repository: String?, val tags: Tags)
     data class ImageRepositories(val imageRepositories: List<ImageRepository>)
     data class Response(val data: ImageRepositories)

--- a/src/test/resources/graphql/queries/getGoboUsage.graphql
+++ b/src/test/resources/graphql/queries/getGoboUsage.graphql
@@ -1,0 +1,7 @@
+{
+    gobo {
+        usage {
+            usedFields
+        }
+    }
+}


### PR DESCRIPTION
- Log queries and mutations (do not log input variables for mutations since these can contain passwords)
- Store used fields in-memory, possible to query the values
- Updated most dependencies, the new version of graphql-java-tools caused issues with relay types. Removed the relay types and created our own Gobo types (such as GoboEdge)
- Updated the ssl and timeout config for WebClient