### PR TITLE
AOS-3289 log exception message

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/GraphQLConfig.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/GraphQLConfig.kt
@@ -1,7 +1,9 @@
 package no.skatteetaten.aurora.gobo
 
 import com.coxautodev.graphql.tools.SchemaParserOptions
-import com.oembedler.moon.graphql.boot.GraphQLWebAutoConfiguration
+import com.oembedler.moon.graphql.boot.GraphQLWebAutoConfiguration.MUTATION_EXECUTION_STRATEGY
+import com.oembedler.moon.graphql.boot.GraphQLWebAutoConfiguration.QUERY_EXECUTION_STRATEGY
+import com.oembedler.moon.graphql.boot.GraphQLWebAutoConfiguration.SUBSCRIPTION_EXECUTION_STRATEGY
 import graphql.execution.AsyncExecutionStrategy
 import graphql.execution.ExecutionStrategy
 import graphql.execution.SubscriptionExecutionStrategy
@@ -24,13 +26,14 @@ class GraphQLConfig {
             .build()
 
     @Bean
-    fun executionStrategies(): Map<String, ExecutionStrategy> =
-        mapOf(
-            GraphQLWebAutoConfiguration.QUERY_EXECUTION_STRATEGY to AsyncExecutionStrategy(
-                GoboDataFetcherExceptionHandler()
-            ), GraphQLWebAutoConfiguration.MUTATION_EXECUTION_STRATEGY to AsyncExecutionStrategy(),
-            GraphQLWebAutoConfiguration.SUBSCRIPTION_EXECUTION_STRATEGY to SubscriptionExecutionStrategy()
+    fun executionStrategies(): Map<String, ExecutionStrategy> {
+        val exceptionHandler = GoboDataFetcherExceptionHandler()
+        return mapOf(
+            QUERY_EXECUTION_STRATEGY to AsyncExecutionStrategy(exceptionHandler),
+            MUTATION_EXECUTION_STRATEGY to AsyncExecutionStrategy(exceptionHandler),
+            SUBSCRIPTION_EXECUTION_STRATEGY to SubscriptionExecutionStrategy(exceptionHandler)
         )
+    }
 
     @Bean
     @ConditionalOnProperty(name = ["gobo.graphql.tracing-enabled"], havingValue = "true", matchIfMissing = false)

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/errorhandling/GoboDataFetcherExceptionHandler.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/resolvers/errorhandling/GoboDataFetcherExceptionHandler.kt
@@ -2,7 +2,10 @@ package no.skatteetaten.aurora.gobo.resolvers.errorhandling
 
 import graphql.execution.DataFetcherExceptionHandler
 import graphql.execution.DataFetcherExceptionHandlerParameters
+import mu.KotlinLogging
 import no.skatteetaten.aurora.gobo.GoboException
+
+private val logger = KotlinLogging.logger { }
 
 class GoboDataFetcherExceptionHandler : DataFetcherExceptionHandler {
     override fun accept(handlerParameters: DataFetcherExceptionHandlerParameters?) {
@@ -11,6 +14,7 @@ class GoboDataFetcherExceptionHandler : DataFetcherExceptionHandler {
         if (handlerParameters.exception is GoboException) {
             handlerParameters.executionContext?.addError(GraphQLExceptionWrapper(handlerParameters))
         }
-        handlerParameters.exception.printStackTrace()
+
+        logger.error { "Exception in data fetcher: ${handlerParameters.exception.message}" }
     }
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/security/openshift.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/security/openshift.kt
@@ -38,7 +38,7 @@ class OpenShiftUserLoader {
         return try {
             DefaultOpenShiftClient(ConfigBuilder().withOauthToken(token).build()).currentUser()
         } catch (e: KubernetesClientException) {
-            logger.info("Exception when trying to get the current user", e)
+            logger.info("Exception when trying to get the current user, ${e.message}")
             null
         }
     }


### PR DESCRIPTION
Only log exception message for:
- `KubernetesClientException` happens many times, usually when the user is not logged in
- Exception in data fetchers, any exception that is thrown from underlying services will be caught here