### PR TITLE
AOS-5416 rename from files to secrets in createVault mutation input

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/vault/Vault.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/vault/Vault.kt
@@ -11,19 +11,17 @@ data class Vault(
     val permissions: List<String>?,
 
     @GraphQLIgnore
-    val secrets: Map<String, String>
+    val secrets: Map<String, String>?
 ) {
     fun secrets() = secrets?.map { Secret(it.key, it.value) }
 }
 
-data class VaultFileInput(val name: String, val base64Content: String)
-
 data class VaultCreationInput(
     val affiliationName: String,
     val vaultName: String,
-    val files: List<VaultFileInput>,
+    val secrets: List<Secret>,
     val permissions: List<String>
 ) {
     @GraphQLIgnore
-    fun mapToPayload() = AuroraSecretVaultPayload(vaultName, permissions, files.map { it.name to it.base64Content }.toMap())
+    fun mapToPayload() = AuroraSecretVaultPayload(vaultName, permissions, secrets.associate { it.key to it.value })
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/vault/Vault.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/vault/Vault.kt
@@ -3,7 +3,7 @@ package no.skatteetaten.aurora.gobo.graphql.vault
 import com.expediagroup.graphql.annotations.GraphQLIgnore
 import no.skatteetaten.aurora.gobo.integration.boober.AuroraSecretVaultPayload
 
-data class Secret(val key: String, val value: String)
+data class Secret(val file: String, val content: String)
 
 data class Vault(
     val name: String,
@@ -23,5 +23,5 @@ data class VaultCreationInput(
     val permissions: List<String>
 ) {
     @GraphQLIgnore
-    fun mapToPayload() = AuroraSecretVaultPayload(vaultName, permissions, secrets.associate { it.key to it.value })
+    fun mapToPayload() = AuroraSecretVaultPayload(vaultName, permissions, secrets.associate { it.file to it.content })
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/vault/Vault.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/vault/Vault.kt
@@ -3,7 +3,7 @@ package no.skatteetaten.aurora.gobo.graphql.vault
 import com.expediagroup.graphql.annotations.GraphQLIgnore
 import no.skatteetaten.aurora.gobo.integration.boober.AuroraSecretVaultPayload
 
-data class Secret(val file: String, val content: String)
+data class Secret(val name: String, val base64Content: String)
 
 data class Vault(
     val name: String,
@@ -23,7 +23,8 @@ data class VaultCreationInput(
     val permissions: List<String>
 ) {
     @GraphQLIgnore
-    fun mapToPayload() = AuroraSecretVaultPayload(vaultName, permissions, secrets.associate { it.file to it.content })
+    fun mapToPayload() =
+        AuroraSecretVaultPayload(vaultName, permissions, secrets.associate { it.name to it.base64Content })
 }
 
 data class DeleteVaultInput(val affiliationName: String, val vaultName: String)

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/graphql/database/DatabaseSchemaMutationTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/graphql/database/DatabaseSchemaMutationTest.kt
@@ -13,7 +13,6 @@ import no.skatteetaten.aurora.gobo.graphql.graphqlDataWithPrefix
 import no.skatteetaten.aurora.gobo.graphql.graphqlDoesNotContainErrors
 import no.skatteetaten.aurora.gobo.graphql.graphqlErrorsMissingToken
 import no.skatteetaten.aurora.gobo.graphql.isTrue
-import no.skatteetaten.aurora.gobo.graphql.printResult
 import no.skatteetaten.aurora.gobo.graphql.queryGraphQL
 import no.skatteetaten.aurora.gobo.integration.dbh.DatabaseService
 import org.junit.jupiter.api.Test
@@ -143,13 +142,10 @@ class DatabaseSchemaMutationTest : GraphQLTestWithDbhAndSkap() {
             token = "test-token"
         )
             .expectBody()
-            .printResult()
-            /*
             .graphqlData("restoreDatabaseSchemas.succeeded.length()").isEqualTo(1)
             .graphqlData("restoreDatabaseSchemas.succeeded[0]").isEqualTo("abc123")
             .graphqlData("restoreDatabaseSchemas.failed.length()").isEqualTo(1)
             .graphqlData("restoreDatabaseSchemas.failed[0]").isEqualTo("bcd234")
-             */
     }
 
     @Test

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/graphql/vault/VaultMutationTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/graphql/vault/VaultMutationTest.kt
@@ -29,13 +29,13 @@ class VaultMutationTest : GraphQLTestWithDbhAndSkap() {
 
     @Test
     fun `Create vault`() {
-        val fileMap = mapOf("name" to "latest.json", "base64Content" to "Z3VycmU=")
+        val secrets = mapOf("key" to "latest.json", "value" to "Z3VycmU=")
         val permissionList = listOf("APP_PaaS_utv")
         val variables = mapOf(
             "input" to mapOf(
                 "affiliationName" to "aurora",
                 "vaultName" to "gurre-test2",
-                "files" to fileMap,
+                "secrets" to secrets,
                 "permissions" to permissionList
             )
         )

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/graphql/vault/VaultMutationTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/graphql/vault/VaultMutationTest.kt
@@ -1,10 +1,5 @@
 package no.skatteetaten.aurora.gobo.graphql.vault
 
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.context.annotation.Import
-import org.springframework.core.io.Resource
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.coEvery
 import no.skatteetaten.aurora.gobo.graphql.GraphQLTestWithDbhAndSkap
@@ -12,6 +7,11 @@ import no.skatteetaten.aurora.gobo.graphql.graphqlData
 import no.skatteetaten.aurora.gobo.graphql.graphqlDoesNotContainErrors
 import no.skatteetaten.aurora.gobo.graphql.queryGraphQL
 import no.skatteetaten.aurora.gobo.integration.boober.VaultService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Import
+import org.springframework.core.io.Resource
 
 @Import(VaultMutation::class)
 class VaultMutationTest : GraphQLTestWithDbhAndSkap() {
@@ -32,7 +32,7 @@ class VaultMutationTest : GraphQLTestWithDbhAndSkap() {
 
     @Test
     fun `Create vault`() {
-        val secrets = mapOf("file" to "latest.json", "content" to "Z3VycmU=")
+        val secrets = mapOf("name" to "latest.json", "base64Content" to "Z3VycmU=")
         val permissionList = listOf("APP_PaaS_utv")
         val variables = mapOf(
             "input" to mapOf(
@@ -42,7 +42,8 @@ class VaultMutationTest : GraphQLTestWithDbhAndSkap() {
                 "permissions" to permissionList
             )
         )
-        webTestClient.queryGraphQL(createVaultMutation, variables, "test-token").expectBody()
+        webTestClient.queryGraphQL(createVaultMutation, variables, "test-token")
+            .expectBody()
             .graphqlData("createVault.name").isEqualTo("test-vault")
             .graphqlDoesNotContainErrors()
     }

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/graphql/vault/VaultMutationTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/graphql/vault/VaultMutationTest.kt
@@ -29,7 +29,7 @@ class VaultMutationTest : GraphQLTestWithDbhAndSkap() {
 
     @Test
     fun `Create vault`() {
-        val secrets = mapOf("key" to "latest.json", "value" to "Z3VycmU=")
+        val secrets = mapOf("file" to "latest.json", "content" to "Z3VycmU=")
         val permissionList = listOf("APP_PaaS_utv")
         val variables = mapOf(
             "input" to mapOf(

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/graphql/vault/VaultQueryTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/graphql/vault/VaultQueryTest.kt
@@ -75,8 +75,8 @@ class VaultQueryTest : GraphQLTestWithDbhAndSkap() {
                 graphqlData("name").isEqualTo("boober")
                 graphqlData("hasAccess").isTrue()
                 graphqlData("permissions").isEqualTo("APP_PaaS_utv")
-                graphqlData("secrets[0].key").isEqualTo("latest.properties")
-                graphqlData("secrets[0].value").isEqualTo("QVRTX1VTRVJOQU1FPWJtYwp")
+                graphqlData("secrets[0].file").isEqualTo("latest.properties")
+                graphqlData("secrets[0].content").isEqualTo("QVRTX1VTRVJOQU1FPWJtYwp")
             }
             .graphqlDoesNotContainErrors()
     }
@@ -94,10 +94,10 @@ class VaultQueryTest : GraphQLTestWithDbhAndSkap() {
                 graphqlData("hasAccess").isTrue()
                 graphqlData("permissions[0]").isEqualTo("APP_PaaS_utv")
                 graphqlData("permissions[1]").isEqualTo("APP_PaaS_drift")
-                graphqlData("secrets[0].key").isEqualTo("pubring-old.gpg")
-                graphqlData("secrets[0].value").isEqualTo("mQGiBEE2LvgRBACfDMHe0CHihg9q5pBpdgyNr2xo9J")
-                graphqlData("secrets[1].key").isEqualTo("pubring.gpg")
-                graphqlData("secrets[1].value").isEqualTo("mQGNBF2yj5wBDADngY7jzndMFkyoMfzoB2p7ih")
+                graphqlData("secrets[0].file").isEqualTo("pubring-old.gpg")
+                graphqlData("secrets[0].content").isEqualTo("mQGiBEE2LvgRBACfDMHe0CHihg9q5pBpdgyNr2xo9J")
+                graphqlData("secrets[1].file").isEqualTo("pubring.gpg")
+                graphqlData("secrets[1].content").isEqualTo("mQGNBF2yj5wBDADngY7jzndMFkyoMfzoB2p7ih")
             }
             .graphqlDoesNotContainErrors()
     }
@@ -114,26 +114,26 @@ class VaultQueryTest : GraphQLTestWithDbhAndSkap() {
                 graphqlData("name").isEqualTo("boober")
                 graphqlData("hasAccess").isTrue()
                 graphqlData("permissions").isEqualTo("APP_PaaS_utv")
-                graphqlData("secrets[0].key").isEqualTo("latest.properties")
-                graphqlData("secrets[0].value").isEqualTo("QVRTX1VTRVJOQU1FPWJtYwp")
+                graphqlData("secrets[0].file").isEqualTo("latest.properties")
+                graphqlData("secrets[0].content").isEqualTo("QVRTX1VTRVJOQU1FPWJtYwp")
             }
             .graphqlDataWithPrefix("affiliations.edges[0].node.vaults[1]") {
                 graphqlData("name").isEqualTo("rosita")
                 graphqlData("hasAccess").isFalse()
                 graphqlData("permissions[0]").isEqualTo("APP_PaaS_utv")
                 graphqlData("permissions[1]").isEqualTo("APP_PaaS_drift")
-                graphqlData("secrets[0].key").isEqualTo("latest.properties")
-                graphqlData("secrets[0].value").isEqualTo("RklPTkFfU0VDUkVUX0tFWT1")
+                graphqlData("secrets[0].file").isEqualTo("latest.properties")
+                graphqlData("secrets[0].content").isEqualTo("RklPTkFfU0VDUkVUX0tFWT1")
             }
             .graphqlDataWithPrefix("affiliations.edges[0].node.vaults[2]") {
                 graphqlData("name").isEqualTo("jenkins-gnupg")
                 graphqlData("hasAccess").isTrue()
                 graphqlData("permissions[0]").isEqualTo("APP_PaaS_utv")
                 graphqlData("permissions[1]").isEqualTo("APP_PaaS_drift")
-                graphqlData("secrets[0].key").isEqualTo("pubring-old.gpg")
-                graphqlData("secrets[0].value").isEqualTo("mQGiBEE2LvgRBACfDMHe0CHihg9q5pBpdgyNr2xo9J")
-                graphqlData("secrets[1].key").isEqualTo("pubring.gpg")
-                graphqlData("secrets[1].value").isEqualTo("mQGNBF2yj5wBDADngY7jzndMFkyoMfzoB2p7ih")
+                graphqlData("secrets[0].file").isEqualTo("pubring-old.gpg")
+                graphqlData("secrets[0].content").isEqualTo("mQGiBEE2LvgRBACfDMHe0CHihg9q5pBpdgyNr2xo9J")
+                graphqlData("secrets[1].file").isEqualTo("pubring.gpg")
+                graphqlData("secrets[1].content").isEqualTo("mQGNBF2yj5wBDADngY7jzndMFkyoMfzoB2p7ih")
             }
             .graphqlDoesNotContainErrors()
     }

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/graphql/vault/VaultQueryTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/graphql/vault/VaultQueryTest.kt
@@ -75,8 +75,8 @@ class VaultQueryTest : GraphQLTestWithDbhAndSkap() {
                 graphqlData("name").isEqualTo("boober")
                 graphqlData("hasAccess").isTrue()
                 graphqlData("permissions").isEqualTo("APP_PaaS_utv")
-                graphqlData("secrets[0].file").isEqualTo("latest.properties")
-                graphqlData("secrets[0].content").isEqualTo("QVRTX1VTRVJOQU1FPWJtYwp")
+                graphqlData("secrets[0].name").isEqualTo("latest.properties")
+                graphqlData("secrets[0].base64Content").isEqualTo("QVRTX1VTRVJOQU1FPWJtYwp")
             }
             .graphqlDoesNotContainErrors()
     }
@@ -94,10 +94,10 @@ class VaultQueryTest : GraphQLTestWithDbhAndSkap() {
                 graphqlData("hasAccess").isTrue()
                 graphqlData("permissions[0]").isEqualTo("APP_PaaS_utv")
                 graphqlData("permissions[1]").isEqualTo("APP_PaaS_drift")
-                graphqlData("secrets[0].file").isEqualTo("pubring-old.gpg")
-                graphqlData("secrets[0].content").isEqualTo("mQGiBEE2LvgRBACfDMHe0CHihg9q5pBpdgyNr2xo9J")
-                graphqlData("secrets[1].file").isEqualTo("pubring.gpg")
-                graphqlData("secrets[1].content").isEqualTo("mQGNBF2yj5wBDADngY7jzndMFkyoMfzoB2p7ih")
+                graphqlData("secrets[0].name").isEqualTo("pubring-old.gpg")
+                graphqlData("secrets[0].base64Content").isEqualTo("mQGiBEE2LvgRBACfDMHe0CHihg9q5pBpdgyNr2xo9J")
+                graphqlData("secrets[1].name").isEqualTo("pubring.gpg")
+                graphqlData("secrets[1].base64Content").isEqualTo("mQGNBF2yj5wBDADngY7jzndMFkyoMfzoB2p7ih")
             }
             .graphqlDoesNotContainErrors()
     }
@@ -114,26 +114,26 @@ class VaultQueryTest : GraphQLTestWithDbhAndSkap() {
                 graphqlData("name").isEqualTo("boober")
                 graphqlData("hasAccess").isTrue()
                 graphqlData("permissions").isEqualTo("APP_PaaS_utv")
-                graphqlData("secrets[0].file").isEqualTo("latest.properties")
-                graphqlData("secrets[0].content").isEqualTo("QVRTX1VTRVJOQU1FPWJtYwp")
+                graphqlData("secrets[0].name").isEqualTo("latest.properties")
+                graphqlData("secrets[0].base64Content").isEqualTo("QVRTX1VTRVJOQU1FPWJtYwp")
             }
             .graphqlDataWithPrefix("affiliations.edges[0].node.vaults[1]") {
                 graphqlData("name").isEqualTo("rosita")
                 graphqlData("hasAccess").isFalse()
                 graphqlData("permissions[0]").isEqualTo("APP_PaaS_utv")
                 graphqlData("permissions[1]").isEqualTo("APP_PaaS_drift")
-                graphqlData("secrets[0].file").isEqualTo("latest.properties")
-                graphqlData("secrets[0].content").isEqualTo("RklPTkFfU0VDUkVUX0tFWT1")
+                graphqlData("secrets[0].name").isEqualTo("latest.properties")
+                graphqlData("secrets[0].base64Content").isEqualTo("RklPTkFfU0VDUkVUX0tFWT1")
             }
             .graphqlDataWithPrefix("affiliations.edges[0].node.vaults[2]") {
                 graphqlData("name").isEqualTo("jenkins-gnupg")
                 graphqlData("hasAccess").isTrue()
                 graphqlData("permissions[0]").isEqualTo("APP_PaaS_utv")
                 graphqlData("permissions[1]").isEqualTo("APP_PaaS_drift")
-                graphqlData("secrets[0].file").isEqualTo("pubring-old.gpg")
-                graphqlData("secrets[0].content").isEqualTo("mQGiBEE2LvgRBACfDMHe0CHihg9q5pBpdgyNr2xo9J")
-                graphqlData("secrets[1].file").isEqualTo("pubring.gpg")
-                graphqlData("secrets[1].content").isEqualTo("mQGNBF2yj5wBDADngY7jzndMFkyoMfzoB2p7ih")
+                graphqlData("secrets[0].name").isEqualTo("pubring-old.gpg")
+                graphqlData("secrets[0].base64Content").isEqualTo("mQGiBEE2LvgRBACfDMHe0CHihg9q5pBpdgyNr2xo9J")
+                graphqlData("secrets[1].name").isEqualTo("pubring.gpg")
+                graphqlData("secrets[1].base64Content").isEqualTo("mQGNBF2yj5wBDADngY7jzndMFkyoMfzoB2p7ih")
             }
             .graphqlDoesNotContainErrors()
     }

--- a/src/test/resources/graphql/queries/getVaults.graphql
+++ b/src/test/resources/graphql/queries/getVaults.graphql
@@ -7,8 +7,8 @@
           hasAccess
           permissions
           secrets{
-            key
-            value
+            file
+            content
           }
         }
       }

--- a/src/test/resources/graphql/queries/getVaults.graphql
+++ b/src/test/resources/graphql/queries/getVaults.graphql
@@ -7,8 +7,8 @@
           hasAccess
           permissions
           secrets{
-            file
-            content
+            name
+            base64Content
           }
         }
       }


### PR DESCRIPTION
Endret fra `files` til `secrets` på input til `createVault`.
Gjenbruker samme `Secret` klasse som bare inneholder key/value som gjøres om til et Map når det sendes til boober.

Skjemaet ser nå sånn ut:
```
input SecretInput {
  key: String!
  value: String!
}

input VaultCreationInput {
  affiliationName: String!
  permissions: [String!]!
  secrets: [SecretInput!]!
  vaultName: String!
}
```