### PR TITLE
graphql-kotlin 4.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-    kotlin("jvm") version "1.4.30"
-    id("no.skatteetaten.gradle.aurora") version "4.2.2"
-    id("org.flywaydb.flyway") version "7.5.3"
+    kotlin("jvm") version "1.4.32"
+    id("no.skatteetaten.gradle.aurora") version "4.2.3"
+    id("org.flywaydb.flyway") version "7.8.1"
 }
 
 aurora {
@@ -19,12 +19,12 @@ aurora {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
 
-    implementation("io.projectreactor.kotlin:reactor-kotlin-extensions:1.1.2")
+    implementation("io.projectreactor.kotlin:reactor-kotlin-extensions:1.1.3")
     implementation("org.apache.commons:commons-text:1.9")
     implementation("org.springframework.boot:spring-boot-starter-security")
-    implementation("com.expediagroup:graphql-kotlin-spring-server:3.7.0")
+    implementation("com.expediagroup:graphql-kotlin-spring-server:4.0.1")
     implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
 
     // Postgres
@@ -38,20 +38,20 @@ dependencies {
         exclude(group = "com.google.guava", module = "guava")
     }
 
-    implementation("io.fabric8:openshift-client:5.0.2")
+    implementation("io.fabric8:openshift-client:5.3.0")
     implementation("com.github.fge:json-patch:1.13")
     implementation("com.jayway.jsonpath:json-path:2.5.0")
-    implementation("io.projectreactor.addons:reactor-extra:3.4.2")
+    implementation("io.projectreactor.addons:reactor-extra:3.4.3")
     implementation("no.skatteetaten.aurora.kubernetes:kubernetes-reactor-coroutines-client:1.3.9")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
-    testImplementation("io.mockk:mockk:1.10.6")
+    testImplementation("io.mockk:mockk:1.11.0")
     testImplementation("com.willowtreeapps.assertk:assertk-jvm:0.23.1")
     testImplementation("io.projectreactor:reactor-test")
     testImplementation("no.skatteetaten.aurora:mockmvc-extensions-kotlin:1.1.6")
     testImplementation("com.ninja-squad:springmockk:3.0.1")
-    testImplementation("org.junit-pioneer:junit-pioneer:1.3.0")
+    testImplementation("org.junit-pioneer:junit-pioneer:1.3.8")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
     testImplementation("no.skatteetaten.aurora:mockmvc-extensions-kotlin:1.1.6")
     testImplementation("com.ninja-squad:springmockk:3.0.1")
     testImplementation("org.junit-pioneer:junit-pioneer:1.3.8")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.3")
 }
 
 task<de.undercouch.gradle.tasks.download.Download>("download-playground") {

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/DataLoaderConfiguration.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/DataLoaderConfiguration.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo
 
-import com.expediagroup.graphql.spring.execution.DataLoaderRegistryFactory
+import com.expediagroup.graphql.server.execution.DataLoaderRegistryFactory
 import graphql.execution.DataFetcherResult
 import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.GlobalScope

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/GraphQLConfig.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/GraphQLConfig.kt
@@ -1,7 +1,7 @@
 package no.skatteetaten.aurora.gobo
 
-import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
-import com.expediagroup.graphql.spring.GraphQLConfigurationProperties
+import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
+import com.expediagroup.graphql.server.spring.GraphQLConfigurationProperties
 import com.fasterxml.jackson.databind.JsonNode
 import graphql.schema.GraphQLScalarType
 import graphql.schema.GraphQLType

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/DataLoader.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/DataLoader.kt
@@ -1,44 +1,27 @@
 package no.skatteetaten.aurora.gobo.graphql
 
+import com.expediagroup.graphql.server.extensions.getValueFromDataLoader
 import graphql.execution.DataFetcherResult
 import graphql.schema.DataFetchingEnvironment
 import kotlinx.coroutines.future.await
 import no.skatteetaten.aurora.gobo.graphql.errorhandling.GraphQLExceptionWrapper
 import java.util.concurrent.CompletableFuture
 
-/**
- * Batches up the loaded keys and calls the data loader once with all keys.
- * Will return a list of values for each key.
- *
- * This function returns a CompletableFuture, must not be called from a suspended function.
- */
-inline fun <Key, reified Value> DataFetchingEnvironment.loadBatchList(
-    key: Key,
-    loaderPrefix: String = Value::class.java.simpleName
-): CompletableFuture<List<Value>> {
-    val loaderName = "${loaderPrefix}BatchDataLoader"
-    val loader = this.getDataLoader<Key, List<Value>>(loaderName)
-        ?: throw IllegalArgumentException("No data loader called $loaderName was found")
-    return loader.load(key, this.getContext())
+inline fun <Key, reified Value> DataFetchingEnvironment.loadValue(key: Key): CompletableFuture<Value> {
+    val loaderName = "${Value::class.simpleName}BatchDataLoader"
+    return this.getValueFromDataLoader(loaderName, key)
 }
 
-/**
- * Batches up the loaded keys and calls the data loader once with all keys.
- * Will return one value for each key.
- *
- * This function returns a CompletableFuture, must not be called from a suspended function.
- */
-inline fun <Key, reified Value> DataFetchingEnvironment.loadBatch(key: Key): CompletableFuture<Value> {
-    val loaderName = "${Value::class.java.simpleName}BatchDataLoader"
-    val loader = this.getDataLoader<Key, Value>(loaderName)
-        ?: throw IllegalArgumentException("No data loader called $loaderName was found")
-    return loader.load(key, this.getContext())
+inline fun <Key, reified Value> DataFetchingEnvironment.loadListValue(key: Key): CompletableFuture<List<Value>> {
+    val loaderName = "${Value::class.simpleName}BatchDataLoader"
+    return this.getValueFromDataLoader(loaderName, key)
 }
 
 /**
  * Load a single key of type Key into a value of type Value using a dataloader named <Value>DataLoader
  * If the loading throws an error the entire query will fail
  */
+@Deprecated(message = "Do not use this function of loading data from dataloader", replaceWith = ReplaceWith("loadValue or loadListValue"))
 suspend inline fun <Key, reified Value> DataFetchingEnvironment.loadOrThrow(
     key: Key,
     loaderPrefix: String = Value::class.java.simpleName
@@ -59,6 +42,7 @@ suspend inline fun <Key, reified Value> DataFetchingEnvironment.loadOrThrow(
  * Load a single key of type Key into a value of type Value using a dataloader named <Value>DataLoader
  * If the loading throws an error the entire query will fail
  */
+@Deprecated(message = "Do not use this function of loading data from dataloader", replaceWith = ReplaceWith("loadValue or loadListValue"))
 suspend inline fun <Key, reified Value> DataFetchingEnvironment.load(
     key: Key,
     loaderPrefix: String = Value::class.java.simpleName
@@ -77,6 +61,7 @@ suspend inline fun <Key, reified Value> DataFetchingEnvironment.load(
  * Load a single key of type Key into a value of type Value using a dataloader named <Value>ListDataLoader
  * If the loading throws an error the entire query will fail
  */
+@Deprecated(message = "Do not use this function of loading data from dataloader", replaceWith = ReplaceWith("loadValue or loadListValue"))
 suspend inline fun <Key, reified Value> DataFetchingEnvironment.loadMany(key: Key): List<Value> {
     val loaderName = "${Value::class.java.simpleName}ListDataLoader"
     val loader = this.getDataLoader<Key, DataFetcherResult<List<Value>>>(loaderName)
@@ -94,6 +79,7 @@ suspend inline fun <Key, reified Value> DataFetchingEnvironment.loadMany(key: Ke
  * Load multiple keys of type Key into a Map grouped by the key and a value of type Value using a dataloader named <Value>MultipleKeysDataLoader
  * If the loading fails it will return a failed DataFetcherResult
  */
+@Deprecated(message = "Do not use this function of loading data from dataloader", replaceWith = ReplaceWith("loadValue or loadListValue"))
 suspend inline fun <Key, reified Value> DataFetchingEnvironment.loadMultipleKeys(keys: List<Key>): Map<Key, DataFetcherResult<Value>> {
     val loaderName = "${Value::class.java.simpleName}MultipleKeysDataLoader"
     val loader = this.getDataLoader<Key, DataFetcherResult<Value>>(loaderName)

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/Instrumentation.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/Instrumentation.kt
@@ -15,8 +15,8 @@ import no.skatteetaten.aurora.gobo.infrastructure.field.FieldService
 import no.skatteetaten.aurora.gobo.removeNewLines
 import no.skatteetaten.aurora.webflux.AuroraRequestParser
 import org.springframework.http.HttpHeaders
-import org.springframework.http.HttpRequest
 import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.server.ServerRequest
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.LongAdder
 import javax.annotation.PreDestroy
@@ -57,7 +57,7 @@ class GoboInstrumentation(
         executionInput?.let {
             val context = (executionInput.context as GoboGraphQLContext)
             val request = context.request
-            logger.debug { """Request hostName="${request.remoteAddress?.hostName}" """ }
+            logger.debug { """Request hostName="${request.remoteAddress().ifPresent { a -> a.hostName }}" """ }
 
             val queryText = it.query.removeNewLines().let { query ->
                 if (query.trimStart().startsWith("mutation")) {
@@ -148,8 +148,9 @@ class ClientUsage {
         }
 }
 
-fun HttpRequest?.klientid() =
-    this?.headers?.getFirst(AuroraRequestParser.KLIENTID_FIELD) ?: this?.headers?.getFirst(HttpHeaders.USER_AGENT)
+fun ServerRequest?.klientid() =
+    this?.headers()?.firstHeader(AuroraRequestParser.KLIENTID_FIELD) ?: this?.headers()
+        ?.firstHeader(HttpHeaders.USER_AGENT)
 
-fun HttpRequest?.korrelasjonsid() =
-    this?.headers?.getFirst(AuroraRequestParser.KORRELASJONSID_FIELD)
+fun ServerRequest?.korrelasjonsid() =
+    this?.headers()?.firstHeader(AuroraRequestParser.KORRELASJONSID_FIELD)

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/affiliation/Affiliation.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/affiliation/Affiliation.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.affiliation
 
-import com.expediagroup.graphql.annotations.GraphQLDescription
+import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import graphql.execution.DataFetcherResult
 import graphql.schema.DataFetchingEnvironment
 import no.skatteetaten.aurora.gobo.graphql.GoboEdge
@@ -20,7 +20,7 @@ import no.skatteetaten.aurora.gobo.security.checkValidUserToken
 
 data class Affiliation(val name: String) {
 
-    suspend fun auroraConfig(refInput: String?, dfe: DataFetchingEnvironment): DataFetcherResult<AuroraConfig?> {
+    suspend fun auroraConfig(refInput: String? = null, dfe: DataFetchingEnvironment): DataFetcherResult<AuroraConfig?> {
         dfe.checkValidUserToken()
         return dfe.load(AuroraConfigKey(name = name, refInput = refInput ?: "master"))
     }
@@ -29,7 +29,7 @@ data class Affiliation(val name: String) {
     suspend fun databaseSchemas(dfe: DataFetchingEnvironment): List<DatabaseSchema> = dfe.loadMany(name)
 
     suspend fun websealStates(dfe: DataFetchingEnvironment): List<WebsealState> = dfe.loadMany(name)
-    suspend fun vaults(names: List<String>?, dfe: DataFetchingEnvironment): DataFetcherResult<List<Vault>> {
+    suspend fun vaults(names: List<String>? = null, dfe: DataFetchingEnvironment): DataFetcherResult<List<Vault>> {
         dfe.checkValidUserToken()
         return if (names.isNullOrEmpty()) {
             newDataFetcherResult(dfe.loadMany(name))

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/affiliation/Affiliation.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/affiliation/Affiliation.kt
@@ -9,7 +9,7 @@ import no.skatteetaten.aurora.gobo.graphql.auroraconfig.AuroraConfig
 import no.skatteetaten.aurora.gobo.graphql.auroraconfig.AuroraConfigKey
 import no.skatteetaten.aurora.gobo.graphql.database.DatabaseSchema
 import no.skatteetaten.aurora.gobo.graphql.load
-import no.skatteetaten.aurora.gobo.graphql.loadBatchList
+import no.skatteetaten.aurora.gobo.graphql.loadListValue
 import no.skatteetaten.aurora.gobo.graphql.loadMany
 import no.skatteetaten.aurora.gobo.graphql.loadOrThrow
 import no.skatteetaten.aurora.gobo.graphql.newDataFetcherResult
@@ -46,7 +46,7 @@ data class Affiliation(val name: String) {
     private fun List<Any>.successes() = this.filterIsInstance<Vault>()
     private fun List<Any>.failures() = this.filterIsInstance<Throwable>()
 
-    fun applications(dfe: DataFetchingEnvironment) = dfe.loadBatchList<String, Application>(name)
+    fun applications(dfe: DataFetchingEnvironment) = dfe.loadListValue<String, Application>(name)
 }
 
 data class AffiliationEdge(

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/affiliation/AffiliationQuery.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/affiliation/AffiliationQuery.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.affiliation
 
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import graphql.schema.DataFetchingEnvironment
 import mu.KotlinLogging
 import no.skatteetaten.aurora.gobo.graphql.GoboGraphQLContext
@@ -14,10 +14,10 @@ private val logger = KotlinLogging.logger { }
 class AffiliationQuery(val affiliationService: AffiliationService) : Query {
 
     suspend fun affiliations(
-        name: String?, // TODO: This query variable is deprecated, replaceWith names
-        names: List<String>?,
-        checkForVisibility: Boolean?,
-        includeUndeployed: Boolean?,
+        name: String? = null, // TODO: This query variable is deprecated, replaceWith names
+        names: List<String>? = null,
+        checkForVisibility: Boolean? = null,
+        includeUndeployed: Boolean? = null,
         dfe: DataFetchingEnvironment
     ): AffiliationsConnection {
 

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/application/ApplicationBatchDataLoader.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/application/ApplicationBatchDataLoader.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.application
 
-import no.skatteetaten.aurora.gobo.KeysBatchDataLoader
+import no.skatteetaten.aurora.gobo.GoboDataLoader
 import no.skatteetaten.aurora.gobo.graphql.GoboGraphQLContext
 import no.skatteetaten.aurora.gobo.graphql.applicationdeployment.ApplicationDeployment
 import no.skatteetaten.aurora.gobo.integration.mokey.ApplicationService
@@ -8,12 +8,9 @@ import org.springframework.stereotype.Component
 
 @Component
 class ApplicationBatchDataLoader(val applicationService: ApplicationService) :
-    KeysBatchDataLoader<String, List<Application>> {
+    GoboDataLoader<String, List<Application>>() {
 
-    override suspend fun getByKeys(
-        affiliations: Set<String>,
-        context: GoboGraphQLContext
-    ): Map<String, List<Application>> {
+    override suspend fun getByKeys(affiliations: Set<String>, ctx: GoboGraphQLContext): Map<String, List<Application>> {
         val applications = applicationService.getApplications(affiliations.toList())
         return affiliations.map { affiliation ->
             val apps = applications.filter { it.applicationDeployments.first().affiliation == affiliation }.map { app ->

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/application/ApplicationQuery.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/application/ApplicationQuery.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.application
 
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import no.skatteetaten.aurora.gobo.integration.mokey.ApplicationService
 import org.springframework.stereotype.Component
 
@@ -9,7 +9,7 @@ class ApplicationQuery(private val applicationService: ApplicationService) : Que
 
     suspend fun applications(
         affiliations: List<String>,
-        applications: List<String>?
+        applications: List<String>? = null
     ): ApplicationsConnection {
         val applicationResources = applicationService.getApplications(affiliations, applications)
         val applicationEdges = createApplicationEdges(applicationResources)

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/applicationdeployment/ApplicationDeploymentBatchDataLoader.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/applicationdeployment/ApplicationDeploymentBatchDataLoader.kt
@@ -1,13 +1,14 @@
 package no.skatteetaten.aurora.gobo.graphql.applicationdeployment
 
-import no.skatteetaten.aurora.gobo.KeysBatchDataLoader
+import no.skatteetaten.aurora.gobo.GoboDataLoader
 import no.skatteetaten.aurora.gobo.graphql.GoboGraphQLContext
 import no.skatteetaten.aurora.gobo.integration.mokey.ApplicationService
 import org.springframework.stereotype.Component
 
 @Component
 class ApplicationDeploymentBatchDataLoader(private val applicationService: ApplicationService) :
-    KeysBatchDataLoader<String, List<ApplicationDeployment>> {
+    GoboDataLoader<String, List<ApplicationDeployment>>() {
+
     override suspend fun getByKeys(
         databaseIds: Set<String>,
         context: GoboGraphQLContext

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/applicationdeployment/ApplicationDeploymentMutation.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/applicationdeployment/ApplicationDeploymentMutation.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.applicationdeployment
 
-import com.expediagroup.graphql.spring.operations.Mutation
+import com.expediagroup.graphql.server.operations.Mutation
 import graphql.schema.DataFetchingEnvironment
 import no.skatteetaten.aurora.gobo.integration.boober.ApplicationDeploymentService
 import no.skatteetaten.aurora.gobo.graphql.token

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/applicationdeployment/ApplicationDeploymentQuery.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/applicationdeployment/ApplicationDeploymentQuery.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.applicationdeployment
 
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import no.skatteetaten.aurora.gobo.graphql.application.Application
 import no.skatteetaten.aurora.gobo.graphql.application.DockerRegistryUtil
 import no.skatteetaten.aurora.gobo.graphql.application.createApplicationEdge

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/applicationdeployment/DeployMutation.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/applicationdeployment/DeployMutation.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.applicationdeployment
 
-import com.expediagroup.graphql.spring.operations.Mutation
+import com.expediagroup.graphql.server.operations.Mutation
 import com.fasterxml.jackson.databind.JsonNode
 import graphql.schema.DataFetchingEnvironment
 import no.skatteetaten.aurora.gobo.integration.boober.ApplicationDeploymentService

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/applicationdeploymentdetails/ApplicationDeploymentDetails.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/applicationdeploymentdetails/ApplicationDeploymentDetails.kt
@@ -62,7 +62,7 @@ data class PodResource(
             )
     }
 
-    fun links(names: List<String>?): List<Link> {
+    fun links(names: List<String>? = null): List<Link> {
         return if (names == null) {
             links
         } else {

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/auroraapimetadata/AuroraApiMetadataQuery.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/auroraapimetadata/AuroraApiMetadataQuery.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.auroraapimetadata
 
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import graphql.schema.DataFetchingEnvironment
 import no.skatteetaten.aurora.gobo.integration.boober.AuroraApiMetadataService
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/auroraconfig/AuroraConfig.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/auroraconfig/AuroraConfig.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.auroraconfig
 
-import com.expediagroup.graphql.annotations.GraphQLIgnore
+import com.expediagroup.graphql.generator.annotations.GraphQLIgnore
 import com.fasterxml.jackson.databind.JsonNode
 import com.jayway.jsonpath.JsonPath
 import graphql.schema.DataFetchingEnvironment
@@ -17,8 +17,8 @@ data class AuroraConfig(
 ) {
 
     suspend fun files(
-        types: List<AuroraConfigFileType>?,
-        fileNames: List<String>?,
+        types: List<AuroraConfigFileType>? = null,
+        fileNames: List<String>? = null,
         dfe: DataFetchingEnvironment
     ): List<AuroraConfigFileResource> {
         dfe.checkValidUserToken()

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/auroraconfig/AuroraConfigMutation.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/auroraconfig/AuroraConfigMutation.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.auroraconfig
 
-import com.expediagroup.graphql.spring.operations.Mutation
+import com.expediagroup.graphql.server.operations.Mutation
 import graphql.schema.DataFetchingEnvironment
 import no.skatteetaten.aurora.gobo.graphql.token
 import no.skatteetaten.aurora.gobo.integration.SourceSystemException

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/auroraconfig/AuroraConfigQuery.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/auroraconfig/AuroraConfigQuery.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.auroraconfig
 
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import graphql.schema.DataFetchingEnvironment
 import no.skatteetaten.aurora.gobo.graphql.token
 import no.skatteetaten.aurora.gobo.integration.boober.AuroraConfigService
@@ -11,6 +11,6 @@ class AuroraConfigQuery(
     private val service: AuroraConfigService
 ) : Query {
 
-    suspend fun auroraConfig(name: String, refInput: String?, dfe: DataFetchingEnvironment) =
+    suspend fun auroraConfig(name: String, refInput: String? = null, dfe: DataFetchingEnvironment) =
         service.getAuroraConfig(dfe.token(), name, refInput ?: "master")
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/certificate/CertificateQuery.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/certificate/CertificateQuery.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.certificate
 
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import graphql.schema.DataFetchingEnvironment
 import no.skatteetaten.aurora.gobo.integration.skap.CertificateService
 import no.skatteetaten.aurora.gobo.security.checkValidUserToken

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/credentials/CredentialMutation.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/credentials/CredentialMutation.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.credentials
 
-import com.expediagroup.graphql.spring.operations.Mutation
+import com.expediagroup.graphql.server.operations.Mutation
 import com.fasterxml.jackson.annotation.JsonProperty
 import graphql.schema.DataFetchingEnvironment
 import mu.KotlinLogging

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/database/Database.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/database/Database.kt
@@ -5,7 +5,7 @@ import no.skatteetaten.aurora.gobo.graphql.GoboEdge
 import no.skatteetaten.aurora.gobo.graphql.GoboPageInfo
 import no.skatteetaten.aurora.gobo.graphql.affiliation.Affiliation
 import no.skatteetaten.aurora.gobo.graphql.applicationdeployment.ApplicationDeployment
-import no.skatteetaten.aurora.gobo.graphql.loadBatchList
+import no.skatteetaten.aurora.gobo.graphql.loadListValue
 import no.skatteetaten.aurora.gobo.integration.dbh.DatabaseInstanceResource
 import no.skatteetaten.aurora.gobo.integration.dbh.DatabaseSchemaResource
 import no.skatteetaten.aurora.gobo.integration.dbh.DatabaseUserResource
@@ -94,7 +94,7 @@ data class DatabaseSchema(
             )
     }
 
-    fun applicationDeployments(dfe: DataFetchingEnvironment) = dfe.loadBatchList<String, ApplicationDeployment>(id)
+    fun applicationDeployments(dfe: DataFetchingEnvironment) = dfe.loadListValue<String, ApplicationDeployment>(id)
 }
 
 data class JdbcUser(

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/database/DatabaseSchemaListDataLoader.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/database/DatabaseSchemaListDataLoader.kt
@@ -2,14 +2,14 @@ package no.skatteetaten.aurora.gobo.graphql.database
 
 import no.skatteetaten.aurora.gobo.KeyDataLoader
 import no.skatteetaten.aurora.gobo.graphql.GoboGraphQLContext
-import no.skatteetaten.aurora.gobo.integration.dbh.DatabaseSchemaResource
+import no.skatteetaten.aurora.gobo.graphql.affiliation.Affiliation
 import no.skatteetaten.aurora.gobo.integration.dbh.DatabaseService
 import org.springframework.stereotype.Component
 
 @Component
 class DatabaseSchemaListDataLoader(val databaseService: DatabaseService) :
-    KeyDataLoader<String, List<DatabaseSchemaResource>> {
+    KeyDataLoader<String, List<DatabaseSchema>> {
 
-    override suspend fun getByKey(affiliation: String, context: GoboGraphQLContext): List<DatabaseSchemaResource> =
-        databaseService.getDatabaseSchemas(affiliation)
+    override suspend fun getByKey(affiliation: String, context: GoboGraphQLContext): List<DatabaseSchema> =
+        databaseService.getDatabaseSchemas(affiliation).map { DatabaseSchema.create(it, Affiliation(affiliation)) }
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/database/DatabaseSchemaMutation.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/database/DatabaseSchemaMutation.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.database
 
-import com.expediagroup.graphql.spring.operations.Mutation
+import com.expediagroup.graphql.server.operations.Mutation
 import graphql.schema.DataFetchingEnvironment
 import no.skatteetaten.aurora.gobo.graphql.affiliation.Affiliation
 import no.skatteetaten.aurora.gobo.integration.dbh.DatabaseService

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/database/DatabaseSchemaQuery.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/database/DatabaseSchemaQuery.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.database
 
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import graphql.schema.DataFetchingEnvironment
 import no.skatteetaten.aurora.gobo.graphql.affiliation.Affiliation
 import no.skatteetaten.aurora.gobo.graphql.pageEdges
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component
 @Component
 class DatabaseSchemaQuery(val databaseService: DatabaseService) : Query {
 
-    suspend fun databaseInstances(affiliation: String?, dfe: DataFetchingEnvironment): List<DatabaseInstance> {
+    suspend fun databaseInstances(affiliation: String? = null, dfe: DataFetchingEnvironment): List<DatabaseInstance> {
         dfe.checkValidUserToken()
         return databaseService
             .getDatabaseInstances()
@@ -30,7 +30,7 @@ class DatabaseSchemaQuery(val databaseService: DatabaseService) : Query {
     suspend fun databaseSchemas(
         affiliations: List<String>,
         first: Int,
-        after: String?,
+        after: String? = null,
         dfe: DataFetchingEnvironment
     ): DatabaseSchemaConnection {
         dfe.checkValidUserToken()

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/environment/Environment.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/environment/Environment.kt
@@ -2,7 +2,7 @@ package no.skatteetaten.aurora.gobo.graphql.environment
 
 import com.expediagroup.graphql.generator.annotations.GraphQLIgnore
 import graphql.schema.DataFetchingEnvironment
-import no.skatteetaten.aurora.gobo.graphql.loadBatch
+import no.skatteetaten.aurora.gobo.graphql.loadValue
 import no.skatteetaten.aurora.gobo.integration.boober.EnvironmentDeploymentRef
 import no.skatteetaten.aurora.gobo.integration.mokey.ApplicationDeploymentResource
 import no.skatteetaten.aurora.gobo.integration.mokey.StatusCheckResource
@@ -64,7 +64,7 @@ data class EnvironmentApplication(
     val autoDeploy = deploymentRef.autoDeploy
 
     fun status(dfe: DataFetchingEnvironment) =
-        dfe.loadBatch<EnvironmentApplication, EnvironmentStatus>(this)
+        dfe.loadValue<EnvironmentApplication, EnvironmentStatus>(this)
 }
 
 data class EnvironmentAffiliation(

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/environment/Environment.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/environment/Environment.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.environment
 
-import com.expediagroup.graphql.annotations.GraphQLIgnore
+import com.expediagroup.graphql.generator.annotations.GraphQLIgnore
 import graphql.schema.DataFetchingEnvironment
 import no.skatteetaten.aurora.gobo.graphql.loadBatch
 import no.skatteetaten.aurora.gobo.integration.boober.EnvironmentDeploymentRef
@@ -73,7 +73,7 @@ data class EnvironmentAffiliation(
     val applications: List<EnvironmentApplication>
 ) {
 
-    fun applications(autoDeployOnly: Boolean?) =
+    fun applications(autoDeployOnly: Boolean? = null) =
         if (autoDeployOnly == true) {
             applications.filter { it.autoDeploy }
         } else {

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/environment/EnvironmentQuery.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/environment/EnvironmentQuery.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.environment
 
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import graphql.schema.DataFetchingEnvironment
 import no.skatteetaten.aurora.gobo.graphql.token
 import no.skatteetaten.aurora.gobo.integration.boober.EnvironmentResource

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/environment/EnvironmentStatusBatchDataLoader.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/environment/EnvironmentStatusBatchDataLoader.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.environment
 
-import no.skatteetaten.aurora.gobo.KeysBatchDataLoader
+import no.skatteetaten.aurora.gobo.GoboDataLoader
 import no.skatteetaten.aurora.gobo.graphql.GoboGraphQLContext
 import no.skatteetaten.aurora.gobo.graphql.applicationdeployment.ApplicationDeploymentRef
 import no.skatteetaten.aurora.gobo.integration.mokey.ApplicationService
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component
 // 2) If status from Phil is success, use status from ApplicationDeployment (Mokey)
 @Component
 class EnvironmentStatusBatchDataLoader(private val applicationService: ApplicationService) :
-    KeysBatchDataLoader<EnvironmentApplication, EnvironmentStatus> {
+    GoboDataLoader<EnvironmentApplication, EnvironmentStatus>() {
 
     override suspend fun getByKeys(keys: Set<EnvironmentApplication>, context: GoboGraphQLContext):
         Map<EnvironmentApplication, EnvironmentStatus> {

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/errorhandling/GraphQLExceptionWrapper.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/errorhandling/GraphQLExceptionWrapper.kt
@@ -4,7 +4,7 @@ import graphql.ErrorType
 import graphql.ExceptionWhileDataFetching
 import graphql.GraphQLError
 import graphql.execution.DataFetcherExceptionHandlerParameters
-import graphql.execution.ExecutionPath
+import graphql.execution.ResultPath
 import graphql.language.SourceLocation
 import no.skatteetaten.aurora.gobo.GoboException
 import no.skatteetaten.aurora.gobo.graphql.GoboGraphQLContext
@@ -20,22 +20,22 @@ class GraphQLExceptionWrapper private constructor(
     },
     private val cause: Throwable? = exception.cause,
     private val location: SourceLocation? = null,
-    private val executionPath: ExecutionPath? = null,
+    private val resultPath: ResultPath? = null,
     private val korrelasjonsId: String? = null
 ) : GraphQLError {
     constructor(handlerParameters: DataFetcherExceptionHandlerParameters) : this(
         exception = handlerParameters.exception,
         location = handlerParameters.sourceLocation,
-        executionPath = handlerParameters.path,
+        resultPath = handlerParameters.path,
         korrelasjonsId = handlerParameters.dataFetchingEnvironment.getContext<GoboGraphQLContext>()?.korrelasjonsid()
     )
 
     constructor(exceptionWhileDataFetching: ExceptionWhileDataFetching) : this(
         exception = exceptionWhileDataFetching.exception,
-        executionPath = exceptionWhileDataFetching.path?.let { ExecutionPath.fromList(it) }
+        resultPath = exceptionWhileDataFetching.path?.let { ResultPath.fromList(it) }
     )
 
-    constructor(exception: Throwable) : this(exception = exception, executionPath = null)
+    constructor(exception: Throwable) : this(exception = exception, resultPath = null)
 
     override fun getExtensions(): Map<String, Any?> =
         when (exception) {
@@ -64,5 +64,5 @@ class GraphQLExceptionWrapper private constructor(
 
     override fun getLocations() = location?.let { mutableListOf(it) } ?: mutableListOf()
 
-    override fun getPath() = executionPath?.toList()?.toMutableList() ?: mutableListOf()
+    override fun getPath() = resultPath?.toList()?.toMutableList() ?: mutableListOf()
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/gobo/GoboQuery.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/gobo/GoboQuery.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.gobo
 
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import graphql.schema.DataFetchingEnvironment
 import no.skatteetaten.aurora.gobo.security.checkValidUserToken
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/gobo/GoboUsage.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/gobo/GoboUsage.kt
@@ -21,8 +21,8 @@ class GoboUsage {
 
     suspend fun usedFields(
         dfe: DataFetchingEnvironment,
-        nameContains: String?,
-        mostUsedOnly: Boolean?
+        nameContains: String? = null,
+        mostUsedOnly: Boolean? = null
     ): List<GoboFieldUsage> {
         val fields = dfe.loadMany<String, GoboFieldUsage>(nameContains ?: "")
         return if (mostUsedOnly == true) {
@@ -32,7 +32,7 @@ class GoboUsage {
         }
     }
 
-    suspend fun clients(dfe: DataFetchingEnvironment, nameContains: String?) =
+    suspend fun clients(dfe: DataFetchingEnvironment, nameContains: String? = null) =
         dfe.loadMany<String, GoboClient>(nameContains ?: "")
 }
 

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/imagerepository/ImageRepository.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/imagerepository/ImageRepository.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.imagerepository
 
-import com.expediagroup.graphql.annotations.GraphQLIgnore
+import com.expediagroup.graphql.generator.annotations.GraphQLIgnore
 import graphql.execution.DataFetcherResult
 import graphql.schema.DataFetchingEnvironment
 import java.time.Instant
@@ -78,10 +78,10 @@ data class ImageRepository(
     }
 
     suspend fun tags(
-        types: List<ImageTagType>?,
-        filter: String?,
+        types: List<ImageTagType>? = null,
+        filter: String? = null,
         first: Int,
-        after: String?,
+        after: String? = null,
         dfe: DataFetchingEnvironment
     ): DataFetcherResult<ImageTagsConnection> {
         val tagsDto = if (!isFullyQualified()) {

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/imagerepository/ImageRepositoryQuery.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/imagerepository/ImageRepositoryQuery.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.imagerepository
 
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import graphql.schema.DataFetchingEnvironment
 import no.skatteetaten.aurora.gobo.GoboException
 import no.skatteetaten.aurora.gobo.security.checkValidUserToken

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/route/Route.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/route/Route.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.route
 
-import com.expediagroup.graphql.annotations.GraphQLIgnore
+import com.expediagroup.graphql.generator.annotations.GraphQLIgnore
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.skatteetaten.aurora.gobo.integration.skap.SkapJob

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/route/RouteQuery.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/route/RouteQuery.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.route
 
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import graphql.schema.DataFetchingEnvironment
 import no.skatteetaten.aurora.gobo.integration.skap.RouteService
 import no.skatteetaten.aurora.gobo.security.checkValidUserToken

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/scan/ScanQuery.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/scan/ScanQuery.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.scan
 
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import no.skatteetaten.aurora.gobo.integration.unclematt.ProbeService
 import no.skatteetaten.aurora.gobo.graphql.scan.Scan.Companion.fromProbeResultList
 import org.springframework.stereotype.Component
@@ -8,6 +8,6 @@ import org.springframework.stereotype.Component
 @Suppress("unused")
 @Component
 class ScanQuery(val scanService: ProbeService) : Query {
-    suspend fun scan(host: String, port: Int?): Scan =
+    suspend fun scan(host: String, port: Int? = null): Scan =
         fromProbeResultList(scanService.probeFirewall(host, port ?: 80))
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/user/CurrentUserQuery.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/user/CurrentUserQuery.kt
@@ -1,7 +1,7 @@
 package no.skatteetaten.aurora.gobo.graphql.user
 
-import com.expediagroup.graphql.annotations.GraphQLDescription
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.generator.annotations.GraphQLDescription
+import com.expediagroup.graphql.server.operations.Query
 import graphql.schema.DataFetchingEnvironment
 import no.skatteetaten.aurora.gobo.graphql.loadOrThrow
 import no.skatteetaten.aurora.gobo.security.currentUser

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/usersettings/UserSettingsMutation.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/usersettings/UserSettingsMutation.kt
@@ -1,7 +1,7 @@
 package no.skatteetaten.aurora.gobo.graphql.usersettings
 
-import com.expediagroup.graphql.annotations.GraphQLDescription
-import com.expediagroup.graphql.spring.operations.Mutation
+import com.expediagroup.graphql.generator.annotations.GraphQLDescription
+import com.expediagroup.graphql.server.operations.Mutation
 import graphql.schema.DataFetchingEnvironment
 import no.skatteetaten.aurora.gobo.integration.boober.UserSettingsService
 import no.skatteetaten.aurora.gobo.graphql.token

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/usersettings/UserSettingsQuery.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/usersettings/UserSettingsQuery.kt
@@ -1,7 +1,7 @@
 package no.skatteetaten.aurora.gobo.graphql.usersettings
 
-import com.expediagroup.graphql.annotations.GraphQLDescription
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.generator.annotations.GraphQLDescription
+import com.expediagroup.graphql.server.operations.Query
 import graphql.schema.DataFetchingEnvironment
 import no.skatteetaten.aurora.gobo.integration.boober.UserSettingsService
 import no.skatteetaten.aurora.gobo.graphql.token

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/vault/Vault.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/vault/Vault.kt
@@ -5,10 +5,10 @@ import no.skatteetaten.aurora.gobo.integration.boober.BooberVault
 data class Vault(
     val name: String,
     val hasAccess: Boolean,
-    val permissions: List<String>?,
-    val secrets: List<Secret>?
+    val permissions: List<String>? = null,
+    val secrets: List<Secret>? = null
 ) {
-    fun secrets(names: List<String>?) =
+    fun secrets(names: List<String>? = null) =
         if (names.isNullOrEmpty()) {
             secrets
         } else {

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/vault/VaultMutation.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/vault/VaultMutation.kt
@@ -1,7 +1,7 @@
 package no.skatteetaten.aurora.gobo.graphql.vault
 
+import com.expediagroup.graphql.server.operations.Mutation
 import org.springframework.stereotype.Component
-import com.expediagroup.graphql.spring.operations.Mutation
 import graphql.schema.DataFetchingEnvironment
 import no.skatteetaten.aurora.gobo.graphql.token
 import no.skatteetaten.aurora.gobo.integration.boober.VaultContext

--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/webseal/WebsealState.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/webseal/WebsealState.kt
@@ -1,6 +1,6 @@
 package no.skatteetaten.aurora.gobo.graphql.webseal
 
-import com.expediagroup.graphql.annotations.GraphQLIgnore
+import com.expediagroup.graphql.generator.annotations.GraphQLIgnore
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import no.skatteetaten.aurora.gobo.integration.skap.WebsealStateResource
 
@@ -20,7 +20,7 @@ data class WebsealState(
     val routeName: String
 ) {
 
-    fun junctions(propertyNames: List<String>?) = junctions.map { junction ->
+    fun junctions(propertyNames: List<String>? = null) = junctions.map { junction ->
         if (propertyNames == null) {
             junction
         } else {

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/graphql/GraphQLTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/graphql/GraphQLTest.kt
@@ -1,7 +1,7 @@
 package no.skatteetaten.aurora.gobo.graphql
 
-import com.expediagroup.graphql.spring.GraphQLAutoConfiguration
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
+import com.expediagroup.graphql.server.spring.GraphQLAutoConfiguration
 import com.ninjasquad.springmockk.MockkBean
 import no.skatteetaten.aurora.gobo.DataLoaderConfiguration
 import no.skatteetaten.aurora.gobo.GraphQLConfig

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/graphql/errorhandling/GraphQLExceptionWrapperTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/graphql/errorhandling/GraphQLExceptionWrapperTest.kt
@@ -6,7 +6,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import graphql.ExceptionWhileDataFetching
 import graphql.execution.DataFetcherExceptionHandlerParameters
-import graphql.execution.ExecutionPath
+import graphql.execution.ResultPath
 import io.mockk.every
 import io.mockk.mockk
 import no.skatteetaten.aurora.gobo.GoboException
@@ -63,7 +63,7 @@ class GraphQLExceptionWrapperTest {
     @Test
     fun `Create new GraphQLExceptionWrapper with ExceptionWhileDataFetching`() {
         val exceptionWhileDataFetching =
-            ExceptionWhileDataFetching(ExecutionPath.rootPath(), AccessDeniedException("test exception"), null)
+            ExceptionWhileDataFetching(ResultPath.rootPath(), AccessDeniedException("test exception"), null)
 
         val exceptionWrapper = GraphQLExceptionWrapper(exceptionWhileDataFetching)
         assertThat(exceptionWrapper.message).isEqualTo("test exception")

--- a/src/test/kotlin/no/skatteetaten/aurora/gobo/security/CurrentUserTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gobo/security/CurrentUserTest.kt
@@ -27,7 +27,6 @@ class CurrentUserTest {
         every { dfe.getContext<GoboGraphQLContext>() } returns GoboGraphQLContext(
             "token",
             mockk(),
-            mockk(),
             Mono.just(securityContext)
         )
     }


### PR DESCRIPTION
1. Use the new `KotlinDataLoader` from graphql-kotlin 4.0
2. Deprecate the old setup and load from dataloaders, in future releases we want all code to use the `KotlinDataLoader`
3. Set default values for all optional fields (new requirement in 4.0)