### PR TITLE
bump webflux-starter version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,6 @@ aurora {
 
     versions {
         springCloudContract = "3.1.3"
-        auroraSpringBootWebFluxStarter = "1.4.5"
     }
 }
 


### PR DESCRIPTION
webflux-starter version oppdateres til 1.4.6 (skjer via aurora-gradle-plugin med 1.4.+)