### PR TITLE
skip trace for root path requests

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,7 +17,7 @@ spring:
         enabled: false
     sleuth:
         web:
-            skip-pattern: "/actuator/.*|/api-docs.*|/swagger.*|.*.png|.*.css|.*.js|.*.html|/favicon.ico|/hystrix.stream"
+            skip-pattern: "/|/actuator/.*|/api-docs.*|/swagger.*|.*.png|.*.css|.*.js|.*.html|/favicon.ico|/hystrix.stream"
 
 graphql:
     packages: "no.skatteetaten.aurora.gobo.graphql"


### PR DESCRIPTION
To avoid reporting trace data on ao requests to the root path