### PR TITLE
AOS-7049: makes cname DataFetcherResult nullable

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/cname/Cname.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gobo/graphql/cname/Cname.kt
@@ -7,7 +7,7 @@ import no.skatteetaten.aurora.gobo.graphql.loadValue
 
 data class Cname(@GraphQLIgnore val affiliation: String) {
 
-    fun azure(dfe: DataFetchingEnvironment) = dfe.loadValue<String, DataFetcherResult<List<CnameAzure>>>(affiliation, loaderClass = CnameAzureDataLoader::class)
+    fun azure(dfe: DataFetchingEnvironment) = dfe.loadValue<String, DataFetcherResult<List<CnameAzure>?>>(affiliation, loaderClass = CnameAzureDataLoader::class)
 
-    fun onPrem(dfe: DataFetchingEnvironment) = dfe.loadValue<String, DataFetcherResult<List<CnameInfo>>>(affiliation, loaderClass = CnameInfoDataLoader::class)
+    fun onPrem(dfe: DataFetchingEnvironment) = dfe.loadValue<String, DataFetcherResult<List<CnameInfo>?>>(affiliation, loaderClass = CnameInfoDataLoader::class)
 }


### PR DESCRIPTION
Løser: `The field at path <path> was declared as a non null type` som kommer hvis tilhørende integrasjon for azure eller onPrem ikke er slått på.